### PR TITLE
feat: use shadcn ScrollArea in conversation component

### DIFF
--- a/apps/test/package.json
+++ b/apps/test/package.json
@@ -13,6 +13,7 @@
     "@repo/elements": "workspace:*",
     "@repo/shadcn-ui": "workspace:*",
     "lucide-react": "^0.515.0",
+    "nanoid": "^5.1.5",
     "next": "15.4.6",
     "react": "19.1.0",
     "react-dom": "19.1.0",

--- a/packages/elements/src/conversation.tsx
+++ b/packages/elements/src/conversation.tsx
@@ -1,12 +1,12 @@
 'use client';
 
+import { Button } from '@repo/shadcn-ui/components/ui/button';
 import { ScrollArea } from '@repo/shadcn-ui/components/ui/scroll-area';
+import { cn } from '@repo/shadcn-ui/lib/utils';
 import { ArrowDownIcon } from 'lucide-react';
 import type { ComponentProps } from 'react';
 import { useCallback } from 'react';
 import { StickToBottom, useStickToBottomContext } from 'use-stick-to-bottom';
-import { Button } from '@/components/ui/button';
-import { cn } from '@/lib/utils';
 
 export type ConversationProps = ComponentProps<typeof StickToBottom>;
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -66,6 +66,9 @@ importers:
       lucide-react:
         specifier: ^0.515.0
         version: 0.515.0(react@19.1.0)
+      nanoid:
+        specifier: ^5.1.5
+        version: 5.1.5
       next:
         specifier: 15.4.6
         version: 15.4.6(@opentelemetry/api@1.9.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -2646,6 +2649,11 @@ packages:
   nanoid@3.3.11:
     resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
+  nanoid@5.1.5:
+    resolution: {integrity: sha512-Ir/+ZpE9fDsNH0hQ3C68uyThDXzYcim2EqcZ8zn8Chtt1iylPT9xXJB0kPCnqzgcEGikO9RxSrh63MsmVCU7Fw==}
+    engines: {node: ^18 || >=20}
     hasBin: true
 
   next-themes@0.4.6:
@@ -5681,6 +5689,8 @@ snapshots:
   ms@2.1.3: {}
 
   nanoid@3.3.11: {}
+
+  nanoid@5.1.5: {}
 
   next-themes@0.4.6(react-dom@19.0.0-rc-f994737d14-20240522(react@19.0.0-rc-f994737d14-20240522))(react@19.0.0-rc-f994737d14-20240522):
     dependencies:


### PR DESCRIPTION
## Summary



**NOTE: Closing this PR as I realize it needs some changes to the `shadcn -> ScrollArea` component to connect with the Viewport primitive ref.**


Replace the default scroll area with shadcn/ui ScrollArea component in the conversation component for better styling consistency and improved theming support.

Also added `nanoid` dep to the `apps/test/package.json` 

## Changes

Shadcn SrollArea in the conversation component

<img width="1318" height="625" alt="image" src="https://github.com/user-attachments/assets/8239fdf8-1e14-47d0-8c68-9e785ea71a7a" />



