### PR TITLE
Fix absolute element scope to button.

### DIFF
--- a/packages/elements/src/actions.tsx
+++ b/packages/elements/src/actions.tsx
@@ -35,7 +35,7 @@ export const Action = ({
   const button = (
     <Button
       className={cn(
-        'size-9 p-1.5 text-muted-foreground hover:text-foreground',
+        'size-9 p-1.5 text-muted-foreground hover:text-foreground relative',
         className
       )}
       size={size}


### PR DESCRIPTION
The Actions component applies a sr-only class for screen reader accessibility, but this causes an unintended side effect where a double scrollbar appears on the page.

<img width="742" height="439" alt="image" src="https://github.com/user-attachments/assets/bf7e42db-127f-4b04-8ca9-8861c641efc5" />

Root cause:
The sr-only class uses position: absolute without a positioned parent container, causing the absolutely positioned element to be positioned relative to the document body or a distant ancestor, which triggers overflow and creates the extra scrollbar.

Add position: relative to the Button component to establish a proper positioning context. This ensures the sr-only element is positioned relative to the Button itself rather than escaping to a parent container.
