### PR TITLE
refactor: update Reasoning component to adjust the auto-close logic

### DIFF
--- a/packages/elements/src/reasoning.tsx
+++ b/packages/elements/src/reasoning.tsx
@@ -38,13 +38,14 @@ export type ReasoningProps = ComponentProps<typeof Collapsible> & {
 };
 
 const AUTO_CLOSE_DELAY = 1000;
+const MS_IN_S = 1000;
 
 export const Reasoning = memo(
   ({
     className,
     isStreaming = false,
     open,
-    defaultOpen = false,
+    defaultOpen = true,
     onOpenChange,
     duration: durationProp,
     children,
@@ -70,23 +71,22 @@ export const Reasoning = memo(
           setStartTime(Date.now());
         }
       } else if (startTime !== null) {
-        setDuration(Math.round((Date.now() - startTime) / 1000));
+        setDuration(Math.round((Date.now() - startTime) / MS_IN_S));
         setStartTime(null);
       }
     }, [isStreaming, startTime, setDuration]);
 
     // Auto-open when streaming starts, auto-close when streaming ends (once only)
     useEffect(() => {
-      if (isStreaming && !isOpen) {
-        setIsOpen(true);
-      } else if (!isStreaming && isOpen && !defaultOpen && !hasAutoClosedRef) {
-        // Add a small delay before closing to allow user to see the content
-        const timer = setTimeout(() => {
-          setIsOpen(false);
-          setHasAutoClosedRef(true);
-        }, AUTO_CLOSE_DELAY);
-        return () => clearTimeout(timer);
-      }
+      if (defaultOpen && !isStreaming && isOpen && !hasAutoClosedRef) {
+          // Add a small delay before closing to allow user to see the content
+          const timer = setTimeout(() => {
+            setIsOpen(false);
+            setHasAutoClosedRef(true);
+          }, AUTO_CLOSE_DELAY);
+
+          return () => clearTimeout(timer);
+        }
     }, [isStreaming, isOpen, defaultOpen, setIsOpen, hasAutoClosedRef]);
 
     const handleOpenChange = (newOpen: boolean) => {
@@ -110,19 +110,10 @@ export const Reasoning = memo(
   }
 );
 
-export type ReasoningTriggerProps = ComponentProps<
-  typeof CollapsibleTrigger
-> & {
-  title?: string;
-};
+export type ReasoningTriggerProps = ComponentProps<typeof CollapsibleTrigger>;
 
 export const ReasoningTrigger = memo(
-  ({
-    className,
-    title = 'Reasoning',
-    children,
-    ...props
-  }: ReasoningTriggerProps) => {
+  ({ className, children, ...props }: ReasoningTriggerProps) => {
     const { isStreaming, isOpen, duration } = useReasoning();
 
     return (


### PR DESCRIPTION
This PR improves the Reasoning component by using the `defaultOpen` prop to control whether the Collapsible can be opened automatically.

When `defaultOpen` is set to `false`, the reasoning section will remain closed until the user explicitly opens it.
Defaulting `defaultOpen` to `true`, the auto-open/close logic is simplified. This change also fixes a bug where the reasoning was being auto-closed the first time a user opened it, due to the auto-close condition.

Additional changes:
- Removed the unused `title` property from ReasoningTrigger.
- Introduced a `MS_IN_S` constant to keep biome happy.