### PR TITLE
Improve registry reliability

### DIFF
--- a/packages/registry/index.js
+++ b/packages/registry/index.js
@@ -37,10 +37,18 @@ if (args.length >= 2 && args[0] === 'add') {
   ).toString();
 
   const [command, ...commandArgs] = commandPrefix.split(' ');
-  spawnSync(command, [...commandArgs, 'shadcn@latest', 'add', targetUrl], {
+  const result = spawnSync(command, [...commandArgs, 'shadcn@latest', 'add', targetUrl], {
     stdio: 'inherit',
     shell: false,
   });
+
+  if (result.error) {
+    console.error('Failed to execute command:', result.error.message);
+    process.exit(1);
+  } else if (result.status !== 0) {
+    console.error(`Command failed with exit code ${result.status}`);
+    process.exit(1);
+  }
 } else {
   const targetUrl = new URL(
     '/all.json',

--- a/packages/registry/index.js
+++ b/packages/registry/index.js
@@ -37,10 +37,14 @@ if (args.length >= 2 && args[0] === 'add') {
   ).toString();
 
   const [command, ...commandArgs] = commandPrefix.split(' ');
-  const result = spawnSync(command, [...commandArgs, 'shadcn@latest', 'add', targetUrl], {
-    stdio: 'inherit',
-    shell: false,
-  });
+  const result = spawnSync(
+    command,
+    [...commandArgs, 'shadcn@latest', 'add', targetUrl],
+    {
+      stdio: 'inherit',
+      shell: false,
+    }
+  );
 
   if (result.error) {
     console.error('Failed to execute command:', result.error.message);
@@ -62,29 +66,29 @@ if (args.length >= 2 && args[0] === 'add') {
         (item) => item.type === 'registry:component'
       );
 
-      for (const item of components) {
-        const componentUrl = new URL(
+      const componentUrls = components.map((item) =>
+        new URL(
           `/${item.name}.json`,
           'https://registry.ai-sdk.dev'
-        ).toString();
+        ).toString()
+      );
 
-        const [command, ...commandArgs] = commandPrefix.split(' ');
-        const result = spawnSync(
-          command,
-          [...commandArgs, 'shadcn@latest', 'add', componentUrl],
-          {
-            stdio: 'inherit',
-            shell: false,
-          }
-        );
-
-        if (result.error) {
-          console.error('Failed to execute command:', result.error.message);
-          process.exit(1);
-        } else if (result.status !== 0) {
-          console.error(`Command failed with exit code ${result.status}`);
-          process.exit(1);
+      const [command, ...commandArgs] = commandPrefix.split(' ');
+      const result = spawnSync(
+        command,
+        [...commandArgs, 'shadcn@latest', 'add', ...componentUrls],
+        {
+          stdio: 'inherit',
+          shell: false,
         }
+      );
+
+      if (result.error) {
+        console.error('Failed to execute command:', result.error.message);
+        process.exit(1);
+      } else if (result.status !== 0) {
+        console.error(`Command failed with exit code ${result.status}`);
+        process.exit(1);
       }
     });
 }

--- a/packages/registry/index.js
+++ b/packages/registry/index.js
@@ -1,19 +1,6 @@
 #!/usr/bin/env node
 
-const { execSync } = require('node:child_process');
-const fs = require('node:fs');
-const path = require('node:path');
-
-console.log('Adding AI Elements...');
-
-// Check for components.json in the current working directory
-const componentsJsonPath = path.join(process.cwd(), 'components.json');
-if (!fs.existsSync(componentsJsonPath)) {
-  console.error(
-    'components.json not found in the current directory. Run `npx shadcn@latest init` to create one.'
-  );
-  process.exit(1);
-}
+const { spawnSync } = require('node:child_process');
 
 // Function to detect the command used to invoke this script
 function getCommandPrefix() {
@@ -48,8 +35,12 @@ if (args.length >= 2 && args[0] === 'add') {
     `/${component}.json`,
     'https://registry.ai-sdk.dev'
   ).toString();
-  console.log(`Adding component: ${component}`);
-  execSync(`${commandPrefix} shadcn@latest add ${targetUrl}`);
+
+  const [command, ...commandArgs] = commandPrefix.split(' ');
+  spawnSync(command, [...commandArgs, 'shadcn@latest', 'add', targetUrl], {
+    stdio: 'inherit',
+    shell: false,
+  });
 } else {
   const targetUrl = new URL(
     '/all.json',
@@ -64,12 +55,20 @@ if (args.length >= 2 && args[0] === 'add') {
       );
 
       for (const item of components) {
-        console.log(`Adding component: ${item.name}`);
         const componentUrl = new URL(
           `/${item.name}.json`,
           'https://registry.ai-sdk.dev'
         ).toString();
-        execSync(`${commandPrefix} shadcn@latest add ${componentUrl}`);
+
+        const [command, ...commandArgs] = commandPrefix.split(' ');
+        spawnSync(
+          command,
+          [...commandArgs, 'shadcn@latest', 'add', componentUrl],
+          {
+            stdio: 'inherit',
+            shell: false,
+          }
+        );
       }
     });
 }

--- a/packages/registry/index.js
+++ b/packages/registry/index.js
@@ -69,7 +69,7 @@ if (args.length >= 2 && args[0] === 'add') {
         ).toString();
 
         const [command, ...commandArgs] = commandPrefix.split(' ');
-        spawnSync(
+        const result = spawnSync(
           command,
           [...commandArgs, 'shadcn@latest', 'add', componentUrl],
           {
@@ -77,6 +77,14 @@ if (args.length >= 2 && args[0] === 'add') {
             shell: false,
           }
         );
+
+        if (result.error) {
+          console.error('Failed to execute command:', result.error.message);
+          process.exit(1);
+        } else if (result.status !== 0) {
+          console.error(`Command failed with exit code ${result.status}`);
+          process.exit(1);
+        }
       }
     });
 }

--- a/packages/registry/package.json
+++ b/packages/registry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-elements",
-  "version": "1.0.9",
+  "version": "1.1.0",
   "description": "AI Elements is a component library and custom registry built on top of shadcn/ui to help you build AI-native applications faster.",
   "bin": {
     "elements": "index.js"


### PR DESCRIPTION
TL;DR:

- More reliable and faster as it uses no shell and passes straight through to shadcn cli
- Don't need components.json check as it can now be created via shadcn cli

Resolves #24
Resolves #52

---

This pull request updates the command execution logic in the `packages/registry/index.js` script, replacing the use of `execSync` with `spawnSync` for running child processes. This change improves reliability and output handling when adding components from the AI SDK registry.

**Command execution improvements:**

* Switched from `execSync` to `spawnSync` for invoking the `shadcn@latest add` command, which provides better control over process output and error handling. [[1]](diffhunk://#diff-06f9a3936ff9511f5087636fa01b2f45baa2913dc0ca673f1c68ce3c62a1a45fL3-R3) [[2]](diffhunk://#diff-06f9a3936ff9511f5087636fa01b2f45baa2913dc0ca673f1c68ce3c62a1a45fL51-R43) [[3]](diffhunk://#diff-06f9a3936ff9511f5087636fa01b2f45baa2913dc0ca673f1c68ce3c62a1a45fL67-R71)

**Code cleanup:**

* Removed unnecessary logging and redundant checks related to adding components, simplifying the script's output. [[1]](diffhunk://#diff-06f9a3936ff9511f5087636fa01b2f45baa2913dc0ca673f1c68ce3c62a1a45fL3-R3) [[2]](diffhunk://#diff-06f9a3936ff9511f5087636fa01b2f45baa2913dc0ca673f1c68ce3c62a1a45fL67-R71)