### PR TITLE
fix: apply classname prop in sources trigger

### DIFF
--- a/packages/elements/src/sources.tsx
+++ b/packages/elements/src/sources.tsx
@@ -28,7 +28,7 @@ export const SourcesTrigger = ({
   children,
   ...props
 }: SourcesTriggerProps) => (
-  <CollapsibleTrigger className="flex items-center gap-2" {...props}>
+  <CollapsibleTrigger className={cn("flex items-center gap-2", className)} {...props}>
     {children ?? (
       <>
         <p className="font-medium">Used {count} sources</p>


### PR DESCRIPTION
# Issue
The `classname` prop was unused for the `SourcesTrigger` component.

# Fix
Applied `classname` prop using `cn`.