### PR TITLE
feat: Add Chat context visualization component

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,24 +78,25 @@ npx shadcn@latest add https://registry.ai-sdk.dev/message.json
 
 AI Elements includes the following components:
 
-| Component | Description |
-|-----------|-------------|
-| `actions` | Interactive action buttons for AI responses |
-| `branch` | Branch visualization for conversation flows |
-| `code-block` | Syntax-highlighted code display with copy functionality |
-| `conversation` | Container for chat conversations |
-| `image` | AI-generated image display component |
-| `inline-citation` | Inline source citations |
-| `loader` | Loading states for AI operations |
-| `message` | Individual chat messages with avatars |
-| `prompt-input` | Advanced input component with model selection |
-| `reasoning` | Display AI reasoning and thought processes |
-| `response` | Formatted AI response display |
-| `source` | Source attribution component |
-| `suggestion` | Quick action suggestions |
-| `task` | Task completion tracking |
-| `tool` | Tool usage visualization |
-| `web-preview` | Embedded web page previews |
+| Component         | Description                                             |
+| ----------------- | ------------------------------------------------------- |
+| `actions`         | Interactive action buttons for AI responses             |
+| `branch`          | Branch visualization for conversation flows             |
+| `code-block`      | Syntax-highlighted code display with copy functionality |
+| `context`         | Display Context consumption                             |
+| `conversation`    | Container for chat conversations                        |
+| `image`           | AI-generated image display component                    |
+| `inline-citation` | Inline source citations                                 |
+| `loader`          | Loading states for AI operations                        |
+| `message`         | Individual chat messages with avatars                   |
+| `prompt-input`    | Advanced input component with model selection           |
+| `reasoning`       | Display AI reasoning and thought processes              |
+| `response`        | Formatted AI response display                           |
+| `source`          | Source attribution component                            |
+| `suggestion`      | Quick action suggestions                                |
+| `task`            | Task completion tracking                                |
+| `tool`            | Tool usage visualization                                |
+| `web-preview`     | Embedded web page previews                              |
 
 ## Quick Start Example
 

--- a/apps/test/app/examples/context.tsx
+++ b/apps/test/app/examples/context.tsx
@@ -1,0 +1,15 @@
+'use client';
+
+import { Context } from '@repo/elements/context';
+
+const Example = () => {
+  return (
+    <div className="flex items-center justify-center p-8">
+      <Context maxTokens={272000} usedTokens={50800} />
+    </div>
+  );
+};
+
+export default Example;
+
+

--- a/apps/test/app/examples/prompt-input.tsx
+++ b/apps/test/app/examples/prompt-input.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { Context } from '@repo/elements/context';
 import {
   PromptInput,
   PromptInputButton,
@@ -27,6 +28,11 @@ const models = [
   { id: 'cohere-command', name: 'Command' },
   { id: 'mistral-7b', name: 'Mistral 7B' },
 ];
+
+const context = {
+  maxTokens: 500_000,
+  usedTokens: 82_100,
+};
 
 const Example = () => {
   const [text, setText] = useState<string>('');
@@ -83,6 +89,10 @@ const Example = () => {
               ))}
             </PromptInputModelSelectContent>
           </PromptInputModelSelect>
+          <Context
+            maxTokens={context.maxTokens}
+            usedTokens={context.usedTokens}
+          />
         </PromptInputTools>
         <PromptInputSubmit disabled={!text} status={status} />
       </PromptInputToolbar>

--- a/apps/test/app/page.tsx
+++ b/apps/test/app/page.tsx
@@ -10,6 +10,7 @@ import CodeBlock from '@/app/examples/code-block';
 import Conversation from '@/app/examples/conversation';
 import Image from '@/app/examples/image';
 import InlineCitation from '@/app/examples/inline-citation';
+import Context from '@/app/examples/context';
 import Loader from '@/app/examples/loader';
 import Message from '@/app/examples/message';
 import PromptInput from '@/app/examples/prompt-input';
@@ -28,6 +29,7 @@ const components = [
   { name: 'Conversation', Component: Conversation },
   { name: 'Image', Component: Image },
   { name: 'InlineCitation', Component: InlineCitation },
+  { name: 'Context', Component: Context },
   { name: 'Loader', Component: Loader },
   { name: 'Message', Component: Message },
   { name: 'PromptInput', Component: PromptInput },

--- a/packages/elements/package.json
+++ b/packages/elements/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@repo/elements",
-  "description": "AI components including message, conversation, input, response, suggestion, sources, tool and branch components for building chat interfaces.",
+  "description": "AI components including message, conversation, input, response, suggestion, sources, context, tool and branch components for building chat interfaces.",
   "version": "0.0.0",
   "private": true,
   "exports": {

--- a/packages/elements/src/context.tsx
+++ b/packages/elements/src/context.tsx
@@ -74,7 +74,6 @@ const ContextIcon = ({ percent }: ContextIconProps) => {
       viewBox={`0 0 ${ICON_VIEWBOX} ${ICON_VIEWBOX}`}
       width="20"
     >
-      <title className="sr-only">Context availability Icon</title>
       <circle
         cx={ICON_CENTER}
         cy={ICON_CENTER}

--- a/packages/elements/src/context.tsx
+++ b/packages/elements/src/context.tsx
@@ -1,0 +1,150 @@
+'use client';
+
+import {
+  HoverCard,
+  HoverCardContent,
+  HoverCardTrigger,
+} from '@repo/shadcn-ui/components/ui/hover-card';
+import { cn } from '@repo/shadcn-ui/lib/utils';
+import type { ComponentProps } from 'react';
+
+export type ContextProps = ComponentProps<'button'> & {
+  /** Total context window size in tokens */
+  maxTokens: number;
+  /** Tokens used so far */
+  usedTokens: number;
+};
+
+const THOUSAND = 1000;
+const MILLION = 1_000_000;
+const BILLION = 1_000_000_000;
+const PERCENT_MAX = 100;
+
+// Lucide CircleIcon geometry
+const ICON_VIEWBOX = 24;
+const ICON_CENTER = 12;
+const ICON_RADIUS = 10;
+const ICON_STROKE_WIDTH = 2;
+
+const formatTokens = (tokens?: number) => {
+  if (tokens === undefined) {
+    return;
+  }
+  if (!Number.isFinite(tokens)) {
+    return;
+  }
+  const abs = Math.abs(tokens);
+  if (abs < THOUSAND) {
+    return `${tokens}`;
+  }
+  if (abs < MILLION) {
+    return `${(tokens / THOUSAND).toFixed(1)}K`;
+  }
+  if (abs < BILLION) {
+    return `${(tokens / MILLION).toFixed(1)}M`;
+  }
+  return `${(tokens / BILLION).toFixed(1)}B`;
+};
+
+const formatPercent = (value: number) => {
+  if (!Number.isFinite(value)) {
+    return '0%';
+  }
+  const rounded = Math.round(value * 10) / 10;
+  return Number.isInteger(rounded)
+    ? `${Math.trunc(rounded)}%`
+    : `${rounded.toFixed(1)}%`;
+};
+
+type ContextIconProps = {
+  percent: number; // 0 - 100
+};
+
+const ContextIcon = ({ percent }: ContextIconProps) => {
+  const radius = ICON_RADIUS;
+  const circumference = 2 * Math.PI * radius;
+  const dashOffset = circumference * (1 - percent / PERCENT_MAX);
+
+  return (
+    <svg
+      aria-label={`${formatPercent(percent)} of model context used`}
+      height="20"
+      role="img"
+      style={{ color: 'currentcolor' }}
+      viewBox={`0 0 ${ICON_VIEWBOX} ${ICON_VIEWBOX}`}
+      width="20"
+    >
+      <title>Context availability</title>
+      <circle
+        cx={ICON_CENTER}
+        cy={ICON_CENTER}
+        fill="none"
+        opacity="0.25"
+        r={radius}
+        stroke="currentColor"
+        strokeWidth={ICON_STROKE_WIDTH}
+      />
+      <circle
+        cx={ICON_CENTER}
+        cy={ICON_CENTER}
+        fill="none"
+        opacity="0.7"
+        r={radius}
+        stroke="currentColor"
+        strokeDasharray={`${circumference} ${circumference}`}
+        strokeDashoffset={dashOffset}
+        strokeLinecap="round"
+        strokeWidth={ICON_STROKE_WIDTH}
+        transform={`rotate(-90 ${ICON_CENTER} ${ICON_CENTER})`}
+      />
+    </svg>
+  );
+};
+
+export const Context = ({
+  className,
+  maxTokens,
+  usedTokens,
+  ...props
+}: ContextProps) => {
+  const safeMax = Math.max(0, Number.isFinite(maxTokens) ? maxTokens : 0);
+  const safeUsed = Math.min(
+    Math.max(0, Number.isFinite(usedTokens) ? usedTokens : 0),
+    safeMax
+  );
+  const usedPercent =
+    safeMax > 0
+      ? Math.min(PERCENT_MAX, Math.max(0, (safeUsed / safeMax) * PERCENT_MAX))
+      : 0;
+
+  const displayPct = formatPercent(Math.round(usedPercent * 10) / 10);
+
+  const used = formatTokens(safeUsed);
+  const total = formatTokens(safeMax);
+  return (
+    <HoverCard closeDelay={100} openDelay={100}>
+      <HoverCardTrigger asChild>
+        <button
+          className={cn(
+            'inline-flex select-none items-center gap-2 rounded-md px-2.5 py-1 text-sm',
+            'bg-background text-foreground'
+          )}
+          type="button"
+          {...props}
+        >
+          <span className="font-medium text-muted-foreground">
+            {displayPct}
+          </span>
+          <ContextIcon percent={usedPercent} />
+        </button>
+      </HoverCardTrigger>
+      <HoverCardContent align="center" className="w-fit p-2">
+        <p className="text-center text-sm">
+          {displayPct} • {used} / {total} context used
+        </p>
+      </HoverCardContent>
+    </HoverCard>
+  );
+};
+
+export default Context;

--- a/packages/elements/src/context.tsx
+++ b/packages/elements/src/context.tsx
@@ -126,7 +126,8 @@ export const Context = ({
         <button
           className={cn(
             'inline-flex select-none items-center gap-2 rounded-md px-2.5 py-1 text-sm',
-            'bg-background text-foreground'
+            'bg-background text-foreground',
+            className
           )}
           type="button"
           {...props}

--- a/packages/elements/src/context.tsx
+++ b/packages/elements/src/context.tsx
@@ -74,7 +74,7 @@ const ContextIcon = ({ percent }: ContextIconProps) => {
       viewBox={`0 0 ${ICON_VIEWBOX} ${ICON_VIEWBOX}`}
       width="20"
     >
-      <title>Context availability</title>
+      <title className="sr-only">Context availability Icon</title>
       <circle
         cx={ICON_CENTER}
         cy={ICON_CENTER}

--- a/packages/examples/src/context.tsx
+++ b/packages/examples/src/context.tsx
@@ -1,0 +1,13 @@
+'use client';
+
+import { Context } from '@repo/elements/context';
+
+const Example = () => {
+  return (
+    <div className="flex items-center justify-center p-8">
+      <Context maxTokens={272_000} usedTokens={50_800} />
+    </div>
+  );
+};
+
+export default Example;


### PR DESCRIPTION
## Add Chat context visualization component

  Add a minimal, opt‑in context component inspired by Cursor’s context indicator to surface “active context” signal in UIs.

  ## Motivation

This one is inspired by the context indicator from Cursor. AI SDK v5 doesn’t expose first‑class “context” yet, but existing telemetry can approximate it well enough to inform users when extra context (files, tools, traces) is being considered.

  ## What’s Included

  - context indicator component (wrapping shadcn HoverCard).

  ## API 

  - ContextIndicator
      - Props: maxTokens, usedTokens
      - Renders a compact text and circle icon to indicate used context and remaining tokens

  ## Notes
  - When AI SDK exposes first‑class context, we can add a tiny helper hook to read it directly without changing the component API.
  - Unsure if I configured biome / ultracite falsely, it went crazy on the inline "magic numbers" - that's why the `context` component looks quite verbose with the constants.

<img width="1348" height="286" alt="prompt-context-example" src="https://github.com/user-attachments/assets/e9f6f751-2d69-476c-a889-5e88b3543498" />


Most importantly - I thought it looked cool!


Edit:
I built a small package called [TokenLens](https://github.com/xn1cklas/tokenlens) that helps to get the needed context data e.g. for the AI SDK. I though don't want to introduce new deps into AI Elemenets.

If we decide to add the Context component to AI Elements, we could link the package and [models.dev ](https://models.dev/) (which my package is built on) to educate how to get the context window data, so people can implement it how they prefer.