### PR TITLE
fix: allow passing a custom title in tool header

### DIFF
--- a/packages/elements/src/tool.tsx
+++ b/packages/elements/src/tool.tsx
@@ -29,6 +29,7 @@ export const Tool = ({ className, ...props }: ToolProps) => (
 );
 
 export type ToolHeaderProps = {
+  title?: string;
   type: ToolUIPart["type"];
   state: ToolUIPart["state"];
   className?: string;
@@ -59,6 +60,7 @@ const getStatusBadge = (status: ToolUIPart["state"]) => {
 
 export const ToolHeader = ({
   className,
+  title,
   type,
   state,
   ...props
@@ -72,7 +74,9 @@ export const ToolHeader = ({
   >
     <div className="flex items-center gap-2">
       <WrenchIcon className="size-4 text-muted-foreground" />
-      <span className="font-medium text-sm">{type}</span>
+      <span className="font-medium text-sm">
+        {title ?? type.split("-").slice(1).join("-")}
+      </span>
       {getStatusBadge(state)}
     </div>
     <ChevronDownIcon className="size-4 text-muted-foreground transition-transform group-data-[state=open]:rotate-180" />


### PR DESCRIPTION
Currently tool shows the tool name as defined by the user along with `tool-` prefix. This pr allows to pass a custom title to it to override it (user can't pass the custom title as type because type is strictly typed). Also updated type to remove the `tool-` part