### PR TITLE
fix(packages): make MessageContent width easily overridable

### DIFF
--- a/packages/elements/src/message.tsx
+++ b/packages/elements/src/message.tsx
@@ -29,12 +29,12 @@ const messageContentVariants = cva(
     variants: {
       variant: {
         contained: [
-          "max-w-[80%] px-4 py-3",
+          "px-4 py-3",
           "group-[.is-user]:bg-primary group-[.is-user]:text-primary-foreground",
           "group-[.is-assistant]:bg-secondary group-[.is-assistant]:text-foreground",
         ],
         flat: [
-          "group-[.is-user]:max-w-[80%] group-[.is-user]:bg-secondary group-[.is-user]:px-4 group-[.is-user]:py-3 group-[.is-user]:text-foreground",
+          "group-[.is-user]:bg-secondary group-[.is-user]:px-4 group-[.is-user]:py-3 group-[.is-user]:text-foreground",
           "group-[.is-assistant]:text-foreground",
         ],
       },
@@ -46,16 +46,24 @@ const messageContentVariants = cva(
 );
 
 export type MessageContentProps = HTMLAttributes<HTMLDivElement> &
-  VariantProps<typeof messageContentVariants>;
+  VariantProps<typeof messageContentVariants> & {
+    maxWidth?: string;
+  };
 
 export const MessageContent = ({
   children,
   className,
   variant,
+  maxWidth = "80%",
+  style,
   ...props
 }: MessageContentProps) => (
   <div
-    className={cn(messageContentVariants({ variant, className }))}
+    className={cn(messageContentVariants({ variant }), className)}
+    style={{
+      maxWidth,
+      ...style,
+    }}
     {...props}
   >
     {children}


### PR DESCRIPTION
closed #68 

## Problem

The `MessageContent` component had hardcoded `max-w-[80%]` CSS classes that were impossible to override, making it difficult to create responsive designs for smaller screens. Users couldn't customize message width even when trying to override with custom classes.

## Solution

  - Removed hardcoded `max-w-[80%]` from CSS variants
  - Added `maxWidth` prop to `MessageContent` component with `"80%"` as default
  - Enabled flexible styling through prop-based width control
  - Maintained backward compatibility with existing implementations

This resolves the issue where users couldn't make responses "look good on small resolutions" due to the inflexible hardcoded width constraint.

I'd appreciate any reviews and feedback. Thank you!