### PR TITLE
add onPaste File Event Support to PromptInput Component

### DIFF
--- a/packages/elements/src/prompt-input.tsx
+++ b/packages/elements/src/prompt-input.tsx
@@ -32,6 +32,7 @@ import { nanoid } from "nanoid";
 import {
   type ChangeEventHandler,
   Children,
+  ClipboardEventHandler,
   type ComponentProps,
   createContext,
   type FormEvent,
@@ -463,6 +464,8 @@ export const PromptInputTextarea = ({
   placeholder = "What would you like to know?",
   ...props
 }: PromptInputTextareaProps) => {
+  const attachments = usePromptInputAttachments();
+
   const handleKeyDown: KeyboardEventHandler<HTMLTextAreaElement> = (e) => {
     if (e.key === "Enter") {
       // Don't submit if IME composition is in progress
@@ -484,6 +487,30 @@ export const PromptInputTextarea = ({
     }
   };
 
+  const handlePaste: ClipboardEventHandler<HTMLTextAreaElement> = (event) => {
+    const items = event.clipboardData?.items;
+    
+    if (!items) {
+      return;
+    }
+
+    const files: File[] = [];
+    
+    for (const item of items) {
+      if (item.kind === "file") {
+        const file = item.getAsFile();
+        if (file) {
+          files.push(file);
+        }
+      }
+    }
+
+    if (files.length > 0) {
+      event.preventDefault();
+      attachments.add(files);
+    }
+  };
+
   return (
     <Textarea
       className={cn(
@@ -498,6 +525,7 @@ export const PromptInputTextarea = ({
         onChange?.(e);
       }}
       onKeyDown={handleKeyDown}
+      onPaste={handlePaste}
       placeholder={placeholder}
       {...props}
     />


### PR DESCRIPTION
This pull request adds support for pasting files directly into the `PromptInputTextarea` component, making it easier for users to attach files via clipboard actions. The main changes focus on handling paste events and integrating with the existing attachments system.

**File attachment via paste:**

* Added a `handlePaste` event handler to `PromptInputTextarea` that detects and extracts files from the clipboard when the user pastes content, then adds them to the attachments using the `usePromptInputAttachments` hook. [[1]](diffhunk://#diff-84351b38bb1ffebf6a4051c22719a5acdc2e5485a2d042b0f312e854de929254R467-R468) [[2]](diffhunk://#diff-84351b38bb1ffebf6a4051c22719a5acdc2e5485a2d042b0f312e854de929254R490-R513)
* Registered the new `handlePaste` handler on the textarea's `onPaste` prop, enabling the paste-to-attach functionality.
* Imported `ClipboardEventHandler` to support typing for the new paste handler.