### PR TITLE
fix(chain-of-thought): memoize Provider value to fix lint warning

### DIFF
--- a/packages/elements/src/chain-of-thought.tsx
+++ b/packages/elements/src/chain-of-thought.tsx
@@ -15,7 +15,7 @@ import {
   type LucideIcon,
 } from "lucide-react";
 import type { ComponentProps } from "react";
-import { createContext, memo, useContext } from "react";
+import { createContext, memo, useContext, useMemo } from "react";
 
 type ChainOfThoughtContextValue = {
   isOpen: boolean;
@@ -57,8 +57,13 @@ export const ChainOfThought = memo(
       onChange: onOpenChange,
     });
 
+    const chainOfThoughtContext = useMemo(
+      () => ({ isOpen, setIsOpen }),
+      [isOpen, setIsOpen]
+    );
+
     return (
-      <ChainOfThoughtContext.Provider value={{ isOpen, setIsOpen }}>
+      <ChainOfThoughtContext.Provider value={chainOfThoughtContext}>
         <div
           className={cn("not-prose max-w-prose space-y-4", className)}
           {...props}


### PR DESCRIPTION
Stabilizes the ChainOfThoughtContext.Provider value using useMemo, resolving react/jsx-no-constructed-context-values lint warnings without changing runtime behavior.


## Background

In ChainOfThought, the ChainOfThoughtContext.Provider receives a new object literal { isOpen, setIsOpen } on every render.
This triggers react/jsx-no-constructed-context-values and may cause unnecessary re-renders.
(attach screenshot of the lint warning here)
<img width="1294" height="156" alt="스크린샷 2025-10-01 오후 1 43 13" src="https://github.com/user-attachments/assets/df65d237-2e43-48e5-be9e-1a9391bb9053" />

## What Changed

Wrapped the value in useMemo so it only updates when isOpen or setIsOpen changes.
This removes the lint warning and prevents extra re-renders.

## Why

- Context providers should have stable references (best practice).
- Improves developer experience by removing a common ESLint warning.
- Prevents unnecessary re-renders.

## Alternatives

- Disable the rule → not ideal for a shared library.
- Keep as-is → warnings and extra renders remain.

## Impact
Same behavior, more efficient and lint-compliant.

## Testing

- Lint error no longer appears.
- Toggle (isOpen / setIsOpen) works as expected.
- Passed tsc and ESLint checks.