### PR TITLE
feat: pressing backspace deletes last attachment when textarea is empty

### DIFF
--- a/packages/elements/src/prompt-input.tsx
+++ b/packages/elements/src/prompt-input.tsx
@@ -795,6 +795,18 @@ export const PromptInputTextarea = ({
       e.preventDefault();
       e.currentTarget.form?.requestSubmit();
     }
+
+    // Remove last attachment when Backspace is pressed and textarea is empty
+    if (
+      e.key === "Backspace" &&
+      e.currentTarget.value === "" &&
+      attachments.files.length > 0
+    ) {
+      e.preventDefault();
+      const lastAttachment =
+        attachments.files[attachments.files.length - 1];
+      attachments.remove(lastAttachment.id);
+    }
   };
 
   const handlePaste: ClipboardEventHandler<HTMLTextAreaElement> = (event) => {


### PR DESCRIPTION
This implements the same behavior found in Cursor => deleting the last added attachment inside the `<PromptInput />` component when the textarea is empty and the user presses the `Backspace` key.