### PR TITLE
fix: resolve onError type conflict in PromptInputProps

### DIFF
--- a/packages/elements/src/prompt-input.tsx
+++ b/packages/elements/src/prompt-input.tsx
@@ -418,7 +418,7 @@ export type PromptInputMessage = {
 
 export type PromptInputProps = Omit<
   HTMLAttributes<HTMLFormElement>,
-  "onSubmit"
+  "onSubmit" | "onError"
 > & {
   accept?: string; // e.g., "image/*" or leave undefined for any
   multiple?: boolean;


### PR DESCRIPTION
Types-only: omit `onError` from `HTMLAttributes<HTMLFormElement>` in `PromptInputProps` to resolve the TS conflict with the component’s custom `onError` (file upload validation: "max_files", "max_file_size", "accept").