### PR TITLE
Prevent form submission during IME composition

### DIFF
--- a/packages/elements/src/prompt-input.tsx
+++ b/packages/elements/src/prompt-input.tsx
@@ -787,10 +787,11 @@ export const PromptInputTextarea = ({
 }: PromptInputTextareaProps) => {
   const controller = useOptionalPromptInputController();
   const attachments = usePromptInputAttachments();
+  const [isComposing, setIsComposing] = useState(false);
 
   const handleKeyDown: KeyboardEventHandler<HTMLTextAreaElement> = (e) => {
     if (e.key === "Enter") {
-      if (e.nativeEvent.isComposing) return;
+      if (isComposing || e.nativeEvent.isComposing) return;
       if (e.shiftKey) return;
       e.preventDefault();
       e.currentTarget.form?.requestSubmit();
@@ -837,6 +838,8 @@ export const PromptInputTextarea = ({
     <InputGroupTextarea
       className={cn("field-sizing-content max-h-48 min-h-16", className)}
       name="message"
+      onCompositionEnd={() => setIsComposing(false)}
+      onCompositionStart={() => setIsComposing(true)}
       onKeyDown={handleKeyDown}
       onPaste={handlePaste}
       placeholder={placeholder}


### PR DESCRIPTION
## Summary

Fixes form submission during IME composition in `PromptInputTextarea`.

## Problem

When users type in Japanese (or other languages requiring IME), pressing Enter to confirm character conversion would incorrectly submit the form instead of just completing the conversion. This made the input field difficult to use for CJK language users.

## Solution

Added explicit composition state tracking using:
- `onCompositionStart`: Sets `isComposing` to `true`
- `onCompositionEnd`: Sets `isComposing` to `false`
- Enhanced `handleKeyDown` to check both the local `isComposing` state and
  `e.nativeEvent.isComposing`

This ensures the Enter key during composition is handled by the IME, not the form submission logic.

## Testing

- Manually tested with Japanese IME input

## Related

- #21