### PR TITLE
ci: run against node v18, 20 and 22 + run ultracite

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,8 +10,12 @@ on:
 
 jobs:
   test:
-    name: Run Tests
+    name: Run Tests (Node.js ${{ matrix.node-version }})
     runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [18, 20, 22]
 
     steps:
       - name: Checkout Repo
@@ -20,13 +24,16 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
 
-      - name: Setup Node.js 22
+      - name: Setup Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: ${{ matrix.node-version }}
 
       - name: Install Dependencies
         run: pnpm i
+
+      - name: Run Check
+        run: pnpm check
 
       - name: Run Tests
         run: pnpm test


### PR DESCRIPTION
As this package officially supports Node.js versions starting from v18, I thought it would be good to introduce the matrix strategy in the CI pipeline to ensure nothing breaks in other versions.

Likewise, I've added `pnpm check` to the pipeline so that we ensure static analysis & formatting runs successfully. On that note, when running it locally I've noticed many errors that I'd love to eventually fix. However, wanted to check here as to not duplicate any existing work or plan?

<img width="1465" height="1546" alt="image" src="https://github.com/user-attachments/assets/7590323a-572a-49a2-8ab0-9cf1da7969c9" />

It would be a lot of changes that I could add to this PR or a separate one for example?