### PR TITLE
fix: add missing PromptInputFooter import in chatbot example

### DIFF
--- a/packages/examples/src/chatbot.tsx
+++ b/packages/examples/src/chatbot.tsx
@@ -25,6 +25,7 @@ import {
   PromptInputBody,
   PromptInputButton,
   PromptInputHeader,
+  PromptInputFooter,
   type PromptInputMessage,
   PromptInputModelSelect,
   PromptInputModelSelectContent,

--- a/packages/examples/src/prompt-input.tsx
+++ b/packages/examples/src/prompt-input.tsx
@@ -21,7 +21,6 @@ import {
   PromptInputSpeechButton,
   PromptInputSubmit,
   PromptInputTextarea,
-  PromptInputFooter,
   PromptInputTools,
   usePromptInputController,
 } from "@repo/elements/prompt-input";


### PR DESCRIPTION
Hey!  Great to see all the updates 👏

Was running `pnpm dev` and hit a small error with missing imports.  Did a quick fix - should be good to go now!

Changes:
- Added missing `PromptInputFooter` import to chatbot example
- Cleaned up a duplicate import in prompt-input example