### PR TITLE
fix: demo claude ui

### DIFF
--- a/packages/examples/src/demo-claude.tsx
+++ b/packages/examples/src/demo-claude.tsx
@@ -653,16 +653,16 @@ const Example = () => {
       </Conversation>
       <div className="grid shrink-0 gap-4 p-4">
         <PromptInput
-          className="divide-y-0 rounded-2xl p-3"
+          className="divide-y-0 bg-card overflow-hidden rounded-md"
           onSubmit={handleSubmit}
         >
           <PromptInputTextarea
-            className="p-0 md:text-base"
+            className="md:text-base"
             onChange={(event) => setText(event.target.value)}
             placeholder="Reply to Claude..."
             value={text}
           />
-          <PromptInputFooter className="p-0">
+          <PromptInputFooter>
             <PromptInputTools>
               <DropdownMenu>
                 <DropdownMenuTrigger asChild>


### PR DESCRIPTION
Fixes the padding bug in the Introduction Page

After:
<img width="1250" height="1294" alt="CleanShot 2025-10-28 at 18 12 15@2x" src="https://github.com/user-attachments/assets/8e6defe1-e22e-42bb-a9b3-11b379484d2a" />

Before:
<img width="1698" height="1280" alt="CleanShot 2025-10-28 at 18 12 51@2x" src="https://github.com/user-attachments/assets/453f0fe1-61ee-44da-92b3-c501504f33d6" />
