### PR TITLE
Chore: add file sample to the queue component sample

### DIFF
--- a/packages/examples/src/queue.tsx
+++ b/packages/examples/src/queue.tsx
@@ -33,7 +33,14 @@ const sampleMessages: QueueMessage[] = [
   },
   {
     id: "msg-3",
-    parts: [{ type: "text", text: "Can you review my PR?" }],
+    parts: [{ type: "text", text: "Update the default logo to this png." },
+      {
+      type: "file",
+      url: "https://github.com/haydenbleasel.png",
+      filename: "setup-guide.png",
+      mediaType: "image/png",
+    }
+    ],
   },
   {
     id: "msg-4",


### PR DESCRIPTION
This PR add the missing attachment sample to the Queue example component

<img width="883" height="379" alt="image" src="https://github.com/user-attachments/assets/e9a79d9d-631a-4202-905b-625db1c6002a" />
