### PR TITLE
fix: shiki dark mode

### DIFF
--- a/apps/docs/app/styles/geistdocs.css
+++ b/apps/docs/app/styles/geistdocs.css
@@ -14,6 +14,18 @@
   html {
     text-rendering: optimizelegibility;
   }
+
+  /* Shiki dark mode styles */
+  html.dark .shiki,
+  html.dark .shiki span {
+    color: var(--shiki-dark) !important;
+    background-color: var(--shiki-dark-bg) !important;
+    /* Optional, if you also want font styles */
+    font-style: var(--shiki-dark-font-style) !important;
+    font-weight: var(--shiki-dark-font-weight) !important;
+    text-decoration: var(--shiki-dark-text-decoration) !important;
+  }
+
   body {
     @apply min-h-dvh;
   }

--- a/apps/docs/components/custom/preview.tsx
+++ b/apps/docs/components/custom/preview.tsx
@@ -100,7 +100,7 @@ export const Preview = async ({ path, className }: ComponentPreviewProps) => {
       </CodeBlockTab>
       <CodeBlockTab className="p-0" value="code">
         <div className="not-prose h-[600px] overflow-y-auto">
-          <CodeBlock>
+          <CodeBlock className="pt-0">
             {/** biome-ignore lint/security/noDangerouslySetInnerHtml: "this is needed." */}
             <pre dangerouslySetInnerHTML={{ __html: highlightedCode }} />
           </CodeBlock>


### PR DESCRIPTION
fix shiki dark mode in the `preview` component.

<img width="1279" height="610" alt="image" src="https://github.com/user-attachments/assets/9e842dc1-555a-43c9-9ce9-0bab6b03342b" />

`apps/docs/components/custom/preview.tsx` is currently a Server Component, so it can't access the resolved theme on client. I followed the class-based dark mode approach from the Shiki documentation to make the theme switching work.
https://shiki.style/guide/dual-themes#class-based-dark-mode


There’s also a spacing issue included in this PR, but I’m not sure about the best way to fix it.

<img width="1246" height="675" alt="image" src="https://github.com/user-attachments/assets/8b6abb70-75f0-4f5c-941a-522969817a26" />
