### PR TITLE
docs: Consolidate '@/components/ai-elements/message' imports on 'elements/conversation'

### DIFF
--- a/apps/docs/content/docs/components/(chatbot)/conversation.mdx
+++ b/apps/docs/content/docs/components/(chatbot)/conversation.mdx
@@ -27,7 +27,11 @@ import {
   ConversationEmptyState,
   ConversationScrollButton,
 } from '@/components/ai-elements/conversation';
-import { Message, MessageContent } from '@/components/ai-elements/message';
+import { 
+  Message, 
+  MessageContent,
+  MessageResponse,
+} from '@/components/ai-elements/message';
 import {
   Input,
   PromptInputTextarea,
@@ -36,7 +40,6 @@ import {
 import { MessageSquare } from 'lucide-react';
 import { useState } from 'react';
 import { useChat } from '@ai-sdk/react';
-import { MessageResponse } from '@/components/ai-elements/message';
 
 const ConversationDemo = () => {
   const [input, setInput] = useState('');


### PR DESCRIPTION
the previous docs had imports like this
```
...
import { Message, MessageContent } from '@/components/ai-elements/message'; 
...
import { MessageResponse } from '@/components/ai-elements/message';
```

This PR combines the imports for '@/components/ai-elements/message'  instead  of them being seperate
```
...
import { 
    Message, 
    MessageContent, 
    MessageResponse
} from '@/components/ai-elements/message';
...
```