### PR TITLE
Updated Links routing to 404

### DIFF
--- a/apps/docs/content/docs/components/(chatbot)/conversation.mdx
+++ b/apps/docs/content/docs/components/(chatbot)/conversation.mdx
@@ -14,7 +14,7 @@ The `Conversation` component wraps messages and automatically scrolls to the bot
 
 ## Usage with AI SDK
 
-Build a simple conversational UI with `Conversation` and [`PromptInput`](/components/prompt-input):
+Build a simple conversational UI with `Conversation` and [`PromptInput`](/elements/components/prompt-input):
 
 Add the following component to your frontend:
 

--- a/apps/docs/content/docs/components/(chatbot)/prompt-input.mdx
+++ b/apps/docs/content/docs/components/(chatbot)/prompt-input.mdx
@@ -14,7 +14,7 @@ The `PromptInput` component allows a user to send a message with file attachment
 
 ## Usage with AI SDK
 
-Build a fully functional chat app using `PromptInput`, [`Conversation`](/components/conversation) with a model picker:
+Build a fully functional chat app using `PromptInput`, [`Conversation`](/elements/components/conversation) with a model picker:
 
 Add the following component to your frontend:
 

--- a/apps/docs/content/docs/components/(workflow)/canvas.mdx
+++ b/apps/docs/content/docs/components/(workflow)/canvas.mdx
@@ -7,7 +7,7 @@ path: elements/components/canvas
 The `Canvas` component provides a React Flow-based canvas for building interactive node-based interfaces. It comes pre-configured with sensible defaults for AI applications, including panning, zooming, and selection behaviors.
 
 <Callout>
-  The Canvas component is designed to be used with the [Node](/components/node) and [Edge](/components/edge) components. See the [Workflow](/examples/workflow) demo for a full example.
+  The Canvas component is designed to be used with the [Node](/elements/components/node) and [Edge](/elements/components/edge) components. See the [Workflow](/elements/examples/workflow) demo for a full example.
 </Callout>
 
 ## Installation

--- a/apps/docs/content/docs/components/(workflow)/connection.mdx
+++ b/apps/docs/content/docs/components/(workflow)/connection.mdx
@@ -7,7 +7,7 @@ path: elements/components/connection
 The `Connection` component provides a styled connection line for React Flow canvases. It renders an animated bezier curve with a circle indicator at the target end, using consistent theming through CSS variables.
 
 <Callout>
-  The Connection component is designed to be used with the [Canvas](/components/canvas) component. See the [Workflow](/examples/workflow) demo for a full example.
+  The Connection component is designed to be used with the [Canvas](/elements/components/canvas) component. See the [Workflow](/elements/examples/workflow) demo for a full example.
 </Callout>
 
 ## Installation

--- a/apps/docs/content/docs/components/(workflow)/controls.mdx
+++ b/apps/docs/content/docs/components/(workflow)/controls.mdx
@@ -7,7 +7,7 @@ path: elements/components/controls
 The `Controls` component provides interactive zoom and fit view controls for React Flow canvases. It includes a modern, themed design with backdrop blur and card styling.
 
 <Callout>
-  The Controls component is designed to be used with the [Canvas](/components/canvas) component. See the [Workflow](/examples/workflow) demo for a full example.
+  The Controls component is designed to be used with the [Canvas](/elements/components/canvas) component. See the [Workflow](/elements/examples/workflow) demo for a full example.
 </Callout>
 
 ## Installation

--- a/apps/docs/content/docs/components/(workflow)/edge.mdx
+++ b/apps/docs/content/docs/components/(workflow)/edge.mdx
@@ -7,7 +7,7 @@ path: elements/components/edge
 The `Edge` component provides two pre-styled edge types for React Flow canvases: `Temporary` for dashed temporary connections and `Animated` for connections with animated indicators.
 
 <Callout>
-  The Edge component is designed to be used with the [Canvas](/components/canvas) component. See the [Workflow](/examples/workflow) demo for a full example.
+  The Edge component is designed to be used with the [Canvas](/elements/components/canvas) component. See the [Workflow](/elements/examples/workflow) demo for a full example.
 </Callout>
 
 ## Installation

--- a/apps/docs/content/docs/components/(workflow)/node.mdx
+++ b/apps/docs/content/docs/components/(workflow)/node.mdx
@@ -7,7 +7,7 @@ path: elements/components/node
 The `Node` component provides a composable, Card-based node for React Flow canvases. It includes support for connection handles, structured layouts, and consistent styling using shadcn/ui components.
 
 <Callout>
-  The Node component is designed to be used with the [Canvas](/components/canvas) component. See the [Workflow](/examples/workflow) demo for a full example.
+  The Node component is designed to be used with the [Canvas](/elements/components/canvas) component. See the [Workflow](/elements/examples/workflow) demo for a full example.
 </Callout>
 
 ## Installation

--- a/apps/docs/content/docs/components/(workflow)/panel.mdx
+++ b/apps/docs/content/docs/components/(workflow)/panel.mdx
@@ -7,7 +7,7 @@ path: elements/components/panel
 The `Panel` component provides a positioned container for custom UI elements on React Flow canvases. It includes modern card styling with backdrop blur and flexible positioning options.
 
 <Callout>
-  The Panel component is designed to be used with the [Canvas](/components/canvas) component. See the [Workflow](/examples/workflow) demo for a full example.
+  The Panel component is designed to be used with the [Canvas](/elements/components/canvas) component. See the [Workflow](/elements/examples/workflow) demo for a full example.
 </Callout>
 
 ## Installation

--- a/apps/docs/content/docs/components/(workflow)/toolbar.mdx
+++ b/apps/docs/content/docs/components/(workflow)/toolbar.mdx
@@ -7,7 +7,7 @@ path: elements/components/toolbar
 The `Toolbar` component provides a positioned toolbar that attaches to nodes in React Flow canvases. It features modern card styling with backdrop blur and flexbox layout for action buttons and controls.
 
 <Callout>
-  The Toolbar component is designed to be used with the [Node](/components/node) component. See the [Workflow](/examples/workflow) demo for a full example.
+  The Toolbar component is designed to be used with the [Node](/elements/components/node) component. See the [Workflow](/elements/examples/workflow) demo for a full example.
 </Callout>
 
 ## Installation

--- a/apps/docs/content/docs/examples/chatbot.mdx
+++ b/apps/docs/content/docs/examples/chatbot.mdx
@@ -307,4 +307,4 @@ export async function POST(req: Request) {
 }
 ```
 
-You now have a working chatbot app with file attachment support! The chatbot can handle both text and file inputs through the action menu. Feel free to explore other components like [`Tool`](/components/tool) or [`Task`](/components/task) to extend your app, or view the other examples.
+You now have a working chatbot app with file attachment support! The chatbot can handle both text and file inputs through the action menu. Feel free to explore other components like [`Tool`](/elements/components/tool) or [`Task`](/elements/components/task) to extend your app, or view the other examples.

--- a/apps/docs/content/docs/examples/v0.mdx
+++ b/apps/docs/content/docs/examples/v0.mdx
@@ -316,4 +316,4 @@ export async function POST(request: NextRequest) {
 
 To start your server, run `pnpm dev`, navigate to `localhost:3000` and try building an app!
 
-You now have a working v0 clone you can build off of! Feel free to explore the [v0 Platform API](https://v0.dev/docs/api/platform) and components like [`Reasoning`](/components/reasoning) and [`Task`](/components/task) to extend your app, or view the other examples.
+You now have a working v0 clone you can build off of! Feel free to explore the [v0 Platform API](https://v0.dev/docs/api/platform) and components like [`Reasoning`](/elements/components/reasoning) and [`Task`](/elements/components/task) to extend your app, or view the other examples.


### PR DESCRIPTION
TLDR; Found 11 pages with links that routes to 404. Fixed them all by providing correct links

**Confirmation steps on the docs:**

1. Route to: https://ai-sdk.dev/elements/components/conversation#usage-with-ai-sdk and click on **PromptInput**
2. Route to: https://ai-sdk.dev/elements/components/prompt-input#usage-with-ai-sdk and click on **Conversation**
3. Route to: https://ai-sdk.dev/elements/components/canvas and click on **Node, Edge and Workflow**
4. Route to: https://ai-sdk.dev/elements/components/connection and click on **Canvas and Workflow**
5. Route to: https://ai-sdk.dev/elements/components/controls and click on **Canvas and Workflow**
6. Route to: https://ai-sdk.dev/elements/components/edge and click on **Canvas and Workflow**
7. Route to: https://ai-sdk.dev/elements/components/node and click on **Canvas and Workflow**
8. Route to: https://ai-sdk.dev/elements/components/panel and click on **Canvas and Workflow**
9. Route to: https://ai-sdk.dev/elements/components/toolbar and click on **Node and Workflow**
10. Route to: https://ai-sdk.dev/elements/examples/chatbot#server > Scroll to the end of the page and click on **Tool and Task**
11. Route to: https://ai-sdk.dev/elements/examples/v0#server > Scroll to the end of the page and click on **Reasoning and Task**