### PR TITLE
feat(prompt-input): add file property to attachment messages for pers…

### DIFF
--- a/.changeset/proud-pots-report.md
+++ b/.changeset/proud-pots-report.md
@@ -1,0 +1,5 @@
+---
+"ai-elements": minor
+---
+
+feat(prompt-input): Add file property to attachment messages for persistent storage

--- a/packages/elements/src/prompt-input.tsx
+++ b/packages/elements/src/prompt-input.tsx
@@ -75,7 +75,7 @@ import {
 // ============================================================================
 
 export type AttachmentsContext = {
-  files: (FileUIPart & { id: string })[];
+  files: (FileUIPart & { id: string, file?: File })[];
   add: (files: File[] | FileList) => void;
   remove: (id: string) => void;
   clear: () => void;
@@ -151,7 +151,7 @@ export function PromptInputProvider({
 
   // ----- attachments state (global when wrapped)
   const [attachmentFiles, setAttachmentFiles] = useState<
-    (FileUIPart & { id: string })[]
+    (FileUIPart & { id: string, file?: File })[]
   >([]);
   const fileInputRef = useRef<HTMLInputElement | null>(null);
   const openRef = useRef<() => void>(() => {});
@@ -170,6 +170,7 @@ export function PromptInputProvider({
           url: URL.createObjectURL(file),
           mediaType: file.type,
           filename: file.name,
+          file,
         }))
       )
     );
@@ -277,7 +278,7 @@ export const usePromptInputAttachments = () => {
 };
 
 export type PromptInputAttachmentProps = HTMLAttributes<HTMLDivElement> & {
-  data: FileUIPart & { id: string };
+  data: FileUIPart & { id: string; file?: File };
   className?: string;
 };
 
@@ -376,7 +377,7 @@ export type PromptInputAttachmentsProps = Omit<
   HTMLAttributes<HTMLDivElement>,
   "children"
 > & {
-  children: (attachment: FileUIPart & { id: string }) => ReactNode;
+  children: (attachment: FileUIPart & { id: string; file?: File }) => ReactNode;
 };
 
 export function PromptInputAttachments({
@@ -429,7 +430,7 @@ export const PromptInputActionAddAttachments = ({
 
 export type PromptInputMessage = {
   text: string;
-  files: FileUIPart[];
+  files: (FileUIPart & { file?: File })[];
 };
 
 export type PromptInputProps = Omit<
@@ -477,7 +478,7 @@ export const PromptInput = ({
   const formRef = useRef<HTMLFormElement | null>(null);
 
   // ----- Local attachments (only used when no provider)
-  const [items, setItems] = useState<(FileUIPart & { id: string })[]>([]);
+  const [items, setItems] = useState<(FileUIPart & { id: string; file?: File })[]>([]);
   const files = usingProvider ? controller.attachments.files : items;
 
   // Keep a ref to files for cleanup on unmount (avoids stale closure)
@@ -537,7 +538,7 @@ export const PromptInput = ({
             message: "Too many files. Some were not added.",
           });
         }
-        const next: (FileUIPart & { id: string })[] = [];
+        const next: (FileUIPart & { id: string, file?: File })[] = [];
         for (const file of capped) {
           next.push({
             id: nanoid(),
@@ -545,6 +546,7 @@ export const PromptInput = ({
             url: URL.createObjectURL(file),
             mediaType: file.type,
             filename: file.name,
+            file,
           });
         }
         return prev.concat(next);
@@ -729,7 +731,7 @@ export const PromptInput = ({
         return item;
       })
     )
-      .then((convertedFiles: FileUIPart[]) => {
+      .then((convertedFiles: (FileUIPart & { file?: File })[]) => {
         try {
           const result = onSubmit({ text, files: convertedFiles }, event);
 


### PR DESCRIPTION
## Description

I encountered a use case similar to the one described in #89, where I need to persist chat messages. This requires the ability to upload files attached via the Prompt Input component.

Currently, the component provides file metadata like id, type, url (a local object URL), mediaType, and filename. However, these properties are insufficient for actual file persistence because:

- The url is a temporary blob link that becomes invalid after the session.

- We lack access to the actual File object, which is required to upload the file data to a server or persistent storage.

## Proposed Solution

I would like to suggest exposing the file property from the component. This would allow users to access the File object directly during the onSubmit event.

With access to the file data, we can then handle the file upload and storage independently, fitting it into our own persistence layer.

## Benefits

**Flexibility**: Enables developers to implement custom file upload workflows.

**Persistence**: Supports use cases where messages (and their associated files) need to be saved permanently.

This is just a suggestion from my perspective, and I believe it would be a helpful addition for others with similar needs. Thank you for considering it!