### PR TITLE
Prevent duplicate attachments when dropping in form and globalDrop is enabled

### DIFF
--- a/packages/elements/src/prompt-input.tsx
+++ b/packages/elements/src/prompt-input.tsx
@@ -603,6 +603,7 @@ export const PromptInput = ({
   useEffect(() => {
     const form = formRef.current;
     if (!form) return;
+    if (globalDrop) return // when global drop is on, let the document-level handler own drops
 
     const onDragOver = (e: DragEvent) => {
       if (e.dataTransfer?.types?.includes("Files")) {
@@ -623,7 +624,7 @@ export const PromptInput = ({
       form.removeEventListener("dragover", onDragOver);
       form.removeEventListener("drop", onDrop);
     };
-  }, [add]);
+  }, [add, globalDrop]);
 
   useEffect(() => {
     if (!globalDrop) return;


### PR DESCRIPTION
right now, if `globalDrop` is true, both document and form event handlers will handle dropping a file, which will duplicate the attachment twice. this disables form-level handler if parent `globalDrop` is true.