### PR TITLE
fix(mcp): use zod/v3 for compatibility with mcp-handler

### DIFF
--- a/.changeset/fix-mcp-zod4.md
+++ b/.changeset/fix-mcp-zod4.md
@@ -1,0 +1,5 @@
+---
+"ai-elements": patch
+---
+
+fix MCP tool `get_ai_elements_component` not exposing component parameter due to Zod 4 incompatibility

--- a/apps/registry/app/api/[transport]/route.ts
+++ b/apps/registry/app/api/[transport]/route.ts
@@ -3,7 +3,7 @@ import { join } from "node:path";
 import { track } from "@vercel/analytics/server";
 import { createMcpHandler } from "mcp-handler";
 import type { RegistryItem } from "shadcn/schema";
-import { z } from "zod";
+import { z } from "zod/v3";
 
 const packageDir = join(process.cwd(), "..", "..", "packages", "elements");
 const srcDir = join(packageDir, "src");
@@ -38,7 +38,11 @@ const handler = createMcpHandler(
     server.tool(
       "get_ai_elements_component",
       "Provides information about an AI Elements component.",
-      { component: z.enum(componentNames as [string, ...string[]]) },
+      {
+        component: z
+          .string()
+          .describe(`Component name. Available: ${componentNames.join(", ")}`),
+      },
       async ({ component }) => {
         const tsxFile = tsxFiles.find(
           (file) => file.name === `${component}.tsx`
@@ -47,7 +51,10 @@ const handler = createMcpHandler(
         if (!tsxFile) {
           return {
             content: [
-              { type: "text", text: `Component ${component} not found` },
+              {
+                type: "text",
+                text: `Component "${component}" not found. Available components: ${componentNames.join(", ")}`,
+              },
             ],
           };
         }


### PR DESCRIPTION
## Summary

Fixes #281

- Fix MCP tool `get_ai_elements_component` not exposing the `component` parameter in `inputSchema`
- Use `zod/v3` import for backward compatibility with `mcp-handler`'s internal `zod-to-json-schema`
- Replace `z.enum()` with `z.string().describe()` for better schema generation

## Problem

The `mcp-handler` package internally depends on `@modelcontextprotocol/sdk@1.22.0`, which uses `zod-to-json-schema` that is incompatible with Zod 4. This caused the `component` parameter to not be exposed in the tool's `inputSchema` (empty `properties` object), resulting in error: `MCP error -32603: t._parse is not a function`.

**Before fix:**
```json
{
  "name": "get_ai_elements_component",
  "inputSchema": {
    "properties": {}  // component parameter missing!
  }
}
```

**After fix:**
```json
{
  "name": "get_ai_elements_component", 
  "inputSchema": {
    "properties": {
      "component": {
        "type": "string",
        "description": "Component name. Available: artifact, canvas, ..."
      }
    },
    "required": ["component"]
  }
}
```

## Test plan

- [x] Verified `tools/list` returns correct `inputSchema` with `component` parameter
- [x] Verified `tools/call` for `get_ai_elements_component` works correctly
- [x] Tested with MCP Inspector using Streamable HTTP transport