### PR TITLE
fix: allow passing onKeyDown prop to PromptInputTextarea

### DIFF
--- a/.changeset/olive-eagles-float.md
+++ b/.changeset/olive-eagles-float.md
@@ -1,0 +1,5 @@
+---
+"ai-elements": patch
+---
+
+allow passing onKeyDown prop to PromptInputTextarea

--- a/packages/elements/src/prompt-input.tsx
+++ b/packages/elements/src/prompt-input.tsx
@@ -818,6 +818,7 @@ export type PromptInputTextareaProps = ComponentProps<
 
 export const PromptInputTextarea = ({
   onChange,
+  onKeyDown,
   className,
   placeholder = "What would you like to know?",
   ...props
@@ -827,6 +828,14 @@ export const PromptInputTextarea = ({
   const [isComposing, setIsComposing] = useState(false);
 
   const handleKeyDown: KeyboardEventHandler<HTMLTextAreaElement> = (e) => {
+    // Call the external onKeyDown handler first
+    onKeyDown?.(e);
+    
+    // If the external handler prevented default, don't run internal logic
+    if (e.defaultPrevented) {
+      return;
+    }
+
     if (e.key === "Enter") {
       if (isComposing || e.nativeEvent.isComposing) {
         return;


### PR DESCRIPTION
Currently, it is possible to define an onKeyDown prop on PromptInputTextarea, but it is not passed to the underlying `InputGroupTextarea`. The `onKeyDown` prop is necessary for implementing features like inline mentions (see #179).