### PR TITLE
Add preferWebSpeechApi prop to SpeechInput component

### DIFF
--- a/packages/elements/src/speech-input.tsx
+++ b/packages/elements/src/speech-input.tsx
@@ -70,6 +70,7 @@ type SpeechInputMode = "speech-recognition" | "media-recorder" | "none";
 
 export type SpeechInputProps = ComponentProps<typeof Button> & {
   onTranscriptionChange?: (text: string) => void;
+  preferWebSpeechApi?: boolean;
   /**
    * Callback for when audio is recorded using MediaRecorder fallback.
    * This is called in browsers that don't support the Web Speech API (Firefox, Safari).
@@ -80,12 +81,12 @@ export type SpeechInputProps = ComponentProps<typeof Button> & {
   lang?: string;
 };
 
-const detectSpeechInputMode = (): SpeechInputMode => {
+const detectSpeechInputMode = (preferWebSpeechApi: boolean): SpeechInputMode => {
   if (typeof window === "undefined") {
     return "none";
   }
 
-  if ("SpeechRecognition" in window || "webkitSpeechRecognition" in window) {
+  if (preferWebSpeechApi && ("SpeechRecognition" in window || "webkitSpeechRecognition" in window)) {
     return "speech-recognition";
   }
 
@@ -100,6 +101,7 @@ export const SpeechInput = ({
   className,
   onTranscriptionChange,
   onAudioRecorded,
+  preferWebSpeechApi = true,
   lang = "en-US",
   ...props
 }: SpeechInputProps) => {
@@ -115,8 +117,8 @@ export const SpeechInput = ({
 
   // Detect mode on mount
   useEffect(() => {
-    setMode(detectSpeechInputMode());
-  }, []);
+    setMode(detectSpeechInputMode(preferWebSpeechApi));
+  }, [preferWebSpeechApi]);
 
   // Initialize Speech Recognition when mode is speech-recognition
   useEffect(() => {


### PR DESCRIPTION
While builtin speech support is nice, consistency is also important.

This option gives developers a way to use the MediaRecorder implementation for all supported browsers, so they can use e.g. OpenAI transcriptions with automated language detection everywhere.

I have not updated any docs, would like to get your feedback first.