### PR TITLE
Fix import path for attachments in chatbot.mdx

### DIFF
--- a/apps/docs/content/docs/examples/chatbot.mdx
+++ b/apps/docs/content/docs/examples/chatbot.mdx
@@ -63,7 +63,7 @@ import {
   AttachmentPreview,
   AttachmentRemove,
   Attachments,
-} from '@/components/ai-elements/attachment';
+} from '@/components/ai-elements/attachments';
 import {
   PromptInput,
   PromptInputActionAddAttachments,


### PR DESCRIPTION
## Context

Following the example described in the documentation after installing `ai-elements` through `npx ai-elements@latest`, I noticed a typechecking issue. It seems like the attachment import in the example is incorrect.