### PR TITLE
fix(docs): correct attachments import path typo

### DIFF
--- a/apps/docs/content/docs/components/(chatbot)/prompt-input.mdx
+++ b/apps/docs/content/docs/components/(chatbot)/prompt-input.mdx
@@ -26,7 +26,7 @@ import {
   AttachmentPreview,
   AttachmentRemove,
   Attachments,
-} from '@/components/ai-elements/attachment';
+} from '@/components/ai-elements/attachments';
 import {
   PromptInput,
   PromptInputActionAddAttachments,

--- a/apps/docs/content/docs/examples/chatbot.mdx
+++ b/apps/docs/content/docs/examples/chatbot.mdx
@@ -63,7 +63,7 @@ import {
   AttachmentPreview,
   AttachmentRemove,
   Attachments,
-} from '@/components/ai-elements/attachment';
+} from '@/components/ai-elements/attachments';
 import {
   PromptInput,
   PromptInputActionAddAttachments,

--- a/skills/ai-elements/references/prompt-input.md
+++ b/skills/ai-elements/references/prompt-input.md
@@ -26,7 +26,7 @@ import {
   AttachmentPreview,
   AttachmentRemove,
   Attachments,
-} from '@/components/ai-elements/attachment';
+} from '@/components/ai-elements/attachments';
 import {
   PromptInput,
   PromptInputActionAddAttachments,


### PR DESCRIPTION
## Summary
- Fixed import path typo in documentation examples
- Changed `@/components/ai-elements/attachment` to `@/components/ai-elements/attachments` 
  to match the actual module name

## Files Changed
- `apps/docs/content/docs/examples/chatbot.mdx`
- `apps/docs/content/docs/components/(chatbot)/prompt-input.mdx`
- `skills/ai-elements/references/prompt-input.md`

## Test Plan
- [x] Documentation builds correctly