### PR TITLE
fix: correct two incorrect or obsolete pieces of demo code in chatbot docs

### DIFF
--- a/apps/docs/content/docs/components/(chatbot)/confirmation.mdx
+++ b/apps/docs/content/docs/components/(chatbot)/confirmation.mdx
@@ -49,7 +49,7 @@ type DeleteFileToolUIPart = ToolUIPart<{
 }>;
 
 const Example = () => {
-  const { messages, sendMessage, status, respondToConfirmationRequest } = useChat({
+  const { messages, sendMessage, status, addToolApprovalResponse } = useChat({
     transport: new DefaultChatTransport({
       api: '/api/chat',
     }),
@@ -90,8 +90,8 @@ const Example = () => {
               <ConfirmationAction
                 variant="outline"
                 onClick={() =>
-                  respondToConfirmationRequest({
-                    approvalId: deleteTool.approval!.id,
+                  addToolApprovalResponse({
+                    id: deleteTool.approval!.id,
                     approved: false,
                   })
                 }
@@ -101,8 +101,8 @@ const Example = () => {
               <ConfirmationAction
                 variant="default"
                 onClick={() =>
-                  respondToConfirmationRequest({
-                    approvalId: deleteTool.approval!.id,
+                  addToolApprovalResponse({
+                    id: deleteTool.approval!.id,
                     approved: true,
                   })
                 }

--- a/apps/docs/content/docs/examples/chatbot.mdx
+++ b/apps/docs/content/docs/examples/chatbot.mdx
@@ -63,7 +63,7 @@ import {
   AttachmentPreview,
   AttachmentRemove,
   Attachments,
-} from '@/components/ai-elements/attachment';
+} from '@/components/ai-elements/attachments';
 import {
   PromptInput,
   PromptInputActionAddAttachments,


### PR DESCRIPTION
* the AI Elements file is `attachments.ts` (plural)
* in AI SDK, tool approvals in the UI are sent via `addToolApprovalResponse` (and the parameter for the ID is just `id`)