### PR TITLE
feat(examples): wire SpeechInput into chatbot prompt footer

### DIFF
--- a/.changeset/slick-ravens-wash.md
+++ b/.changeset/slick-ravens-wash.md
@@ -1,0 +1,5 @@
+---
+"ai-elements": patch
+---
+
+feat(examples): wire SpeechInput into chatbot prompt footer

--- a/packages/examples/src/chatbot.tsx
+++ b/packages/examples/src/chatbot.tsx
@@ -62,9 +62,10 @@ import {
   SourcesContent,
   SourcesTrigger,
 } from "@repo/elements/sources";
+import { SpeechInput } from "@repo/elements/speech-input";
 import { Suggestion, Suggestions } from "@repo/elements/suggestion";
 import type { ToolUIPart } from "ai";
-import { CheckIcon, GlobeIcon, MicIcon } from "lucide-react";
+import { CheckIcon, GlobeIcon } from "lucide-react";
 import { nanoid } from "nanoid";
 import { useCallback, useState } from "react";
 import { toast } from "sonner";
@@ -361,7 +362,6 @@ const Example = () => {
   const [modelSelectorOpen, setModelSelectorOpen] = useState(false);
   const [text, setText] = useState<string>("");
   const [useWebSearch, setUseWebSearch] = useState<boolean>(false);
-  const [useMicrophone, setUseMicrophone] = useState<boolean>(false);
   const [status, setStatus] = useState<
     "submitted" | "streaming" | "ready" | "error"
   >("ready");
@@ -471,6 +471,10 @@ const Example = () => {
     addUserMessage(suggestion);
   };
 
+  const handleTranscriptionChange = useCallback((transcript: string) => {
+    setText((prev) => (prev ? `${prev} ${transcript}` : transcript));
+  }, []);
+
   return (
     <div className="relative flex size-full flex-col divide-y overflow-hidden">
       <Conversation>
@@ -554,13 +558,12 @@ const Example = () => {
                     <PromptInputActionAddAttachments />
                   </PromptInputActionMenuContent>
                 </PromptInputActionMenu>
-                <PromptInputButton
-                  onClick={() => setUseMicrophone(!useMicrophone)}
-                  variant={useMicrophone ? "default" : "ghost"}
-                >
-                  <MicIcon size={16} />
-                  <span className="sr-only">Microphone</span>
-                </PromptInputButton>
+                <SpeechInput
+                  className="shrink-0"
+                  onTranscriptionChange={handleTranscriptionChange}
+                  size="icon-sm"
+                  variant="ghost"
+                />
                 <PromptInputButton
                   onClick={() => setUseWebSearch(!useWebSearch)}
                   variant={useWebSearch ? "default" : "ghost"}


### PR DESCRIPTION
The [Chatbot](https://elements.ai-sdk.dev/examples/chatbot) example is using a static voice element with just state change of the icon, this PR extends the `SpeechInput` as shown below.

<img width="1920" height="993" alt="image" src="https://github.com/user-attachments/assets/575823e8-d470-4bb2-841f-e63d4415432b" />

Addresses: [#93](https://github.com/vercel/ai-elements/issues/93#issuecomment-3837396927)