### PR TITLE
feat(elements): add composable choice component

### DIFF
--- a/apps/docs/content/components/(chatbot)/choice.mdx
+++ b/apps/docs/content/components/(chatbot)/choice.mdx
@@ -4,7 +4,7 @@ description: A composable component for AI-driven clarification prompts where us
 path: elements/components/choice
 ---
 
-The `Choice` component is designed for AI workflows where the model asks users to resolve ambiguity with structured options (timeframe, severity, scope, category, and similar constraints).
+The `Choice` component lets users pick from a set of options when an AI model needs clarification before continuing.
 
 <Preview path="choice" />
 
@@ -22,7 +22,10 @@ Add the following component to your frontend:
 "use client";
 
 import type { ToolUIPart, UIMessage } from "ai";
-import { DefaultChatTransport, lastAssistantMessageIsCompleteWithToolCalls } from "ai";
+import {
+  DefaultChatTransport,
+  lastAssistantMessageIsCompleteWithToolCalls,
+} from "ai";
 import { useChat } from "@ai-sdk/react";
 import {
   Choice,
@@ -52,9 +55,8 @@ type AskUserPart = ToolUIPart<{
   };
 }>;
 
-const isAskUserPart = (
-  part: UIMessage["parts"][number]
-): part is AskUserPart => part.type === "tool-ask_user";
+const isAskUserPart = (part: UIMessage["parts"][number]): part is AskUserPart =>
+  part.type === "tool-ask_user";
 
 const Example = () => {
   const { messages, addToolOutput, status } = useChat({
@@ -71,6 +73,21 @@ const Example = () => {
           message.parts.map((part) => {
             if (!isAskUserPart(part) || part.state === "input-streaming") {
               return null;
+            }
+
+            // Show compact summary when choice has been submitted
+            if (part.state === "output-available") {
+              const output = part.output;
+              const values = Array.isArray(output) ? output : [output];
+              const labels = values.map(
+                (v) =>
+                  part.input.options.find((o) => o.value === v)?.label ?? v
+              );
+              return (
+                <ChoiceStatus key={part.toolCallId}>
+                  {labels.join(", ")}
+                </ChoiceStatus>
+              );
             }
 
             const multiSelect = Boolean(part.input.multi_select);
@@ -109,7 +126,8 @@ const Example = () => {
                 ) : null}
                 {part.state === "output-error" ? (
                   <ChoiceStatus status="error">
-                    {part.errorText ?? "Could not submit your selection. Try again."}
+                    {part.errorText ??
+                      "Could not submit your selection. Try again."}
                   </ChoiceStatus>
                 ) : null}
               </Choice>
@@ -127,7 +145,13 @@ export default Example;
 Add the following route to your backend:
 
 ```ts title="app/api/chat/route.ts"
-import { convertToModelMessages, stepCountIs, streamText, tool, UIMessage } from "ai";
+import {
+  convertToModelMessages,
+  stepCountIs,
+  streamText,
+  tool,
+  UIMessage,
+} from "ai";
 import { z } from "zod";
 
 export async function POST(req: Request) {
@@ -169,7 +193,7 @@ export async function POST(req: Request) {
 - Optional auto-submit on single selection
 - Built-in confirm action for multi-select workflows
 - Keyboard and screen-reader friendly option semantics
-- Composable structure for custom layouts and states
+- Composable structure for custom layouts and resolved states
 
 ## Examples
 
@@ -180,6 +204,10 @@ export async function POST(req: Request) {
 ### Multiple Select
 
 <Preview path="choice-multiple" />
+
+### Resolved State
+
+After submission, replace the interactive options with a compact summary. Both examples above demonstrate this pattern — select an option to see the resolved view.
 
 ## Props
 

--- a/packages/elements/__tests__/choice.test.tsx
+++ b/packages/elements/__tests__/choice.test.tsx
@@ -15,18 +15,20 @@ describe("choice", () => {
   it("renders a labelled options group", () => {
     render(
       <Choice>
-        <ChoiceQuestion>What should we focus on?</ChoiceQuestion>
+        <ChoiceQuestion>How detailed should the response be?</ChoiceQuestion>
         <ChoiceOptions>
-          <ChoiceOption value="crime">Crime</ChoiceOption>
-          <ChoiceOption value="events">Events</ChoiceOption>
+          <ChoiceOption value="brief">Brief</ChoiceOption>
+          <ChoiceOption value="detailed">Detailed</ChoiceOption>
         </ChoiceOptions>
       </Choice>
     );
 
     expect(
-      screen.getByRole("group", { name: "What should we focus on?" })
+      screen.getByRole("group", {
+        name: "How detailed should the response be?",
+      })
     ).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Crime" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Brief" })).toBeInTheDocument();
   });
 
   it("selects one option in single mode and auto-submits by default", async () => {
@@ -38,18 +40,18 @@ describe("choice", () => {
       <Choice onSubmit={onSubmit} onValueChange={onValueChange}>
         <ChoiceQuestion>Pick one</ChoiceQuestion>
         <ChoiceOptions>
-          <ChoiceOption value="high">High priority</ChoiceOption>
-          <ChoiceOption value="low">Low priority</ChoiceOption>
+          <ChoiceOption value="brief">Brief</ChoiceOption>
+          <ChoiceOption value="detailed">Detailed</ChoiceOption>
         </ChoiceOptions>
       </Choice>
     );
 
-    const high = screen.getByRole("button", { name: "High priority" });
-    await user.click(high);
+    const brief = screen.getByRole("button", { name: "Brief" });
+    await user.click(brief);
 
-    expect(onValueChange).toHaveBeenCalledWith("high");
-    expect(onSubmit).toHaveBeenCalledWith("high");
-    expect(high).toHaveAttribute("aria-pressed", "true");
+    expect(onValueChange).toHaveBeenCalledWith("brief");
+    expect(onSubmit).toHaveBeenCalledWith("brief");
+    expect(brief).toHaveAttribute("aria-pressed", "true");
   });
 
   it("toggles options in multiple mode", async () => {
@@ -60,24 +62,27 @@ describe("choice", () => {
       <Choice multiple onValueChange={onValueChange}>
         <ChoiceQuestion>Select all that apply</ChoiceQuestion>
         <ChoiceOptions>
-          <ChoiceOption value="alerts">Alerts</ChoiceOption>
-          <ChoiceOption value="permits">Permits</ChoiceOption>
+          <ChoiceOption value="key-points">Key points</ChoiceOption>
+          <ChoiceOption value="sources">Sources</ChoiceOption>
         </ChoiceOptions>
       </Choice>
     );
 
-    const alerts = screen.getByRole("button", { name: "Alerts" });
-    const permits = screen.getByRole("button", { name: "Permits" });
+    const keyPoints = screen.getByRole("button", { name: "Key points" });
+    const sources = screen.getByRole("button", { name: "Sources" });
 
-    await user.click(alerts);
-    await user.click(permits);
-    await user.click(alerts);
+    await user.click(keyPoints);
+    await user.click(sources);
+    await user.click(keyPoints);
 
-    expect(onValueChange).toHaveBeenNthCalledWith(1, ["alerts"]);
-    expect(onValueChange).toHaveBeenNthCalledWith(2, ["alerts", "permits"]);
-    expect(onValueChange).toHaveBeenNthCalledWith(3, ["permits"]);
-    expect(alerts).toHaveAttribute("aria-pressed", "false");
-    expect(permits).toHaveAttribute("aria-pressed", "true");
+    expect(onValueChange).toHaveBeenNthCalledWith(1, ["key-points"]);
+    expect(onValueChange).toHaveBeenNthCalledWith(2, [
+      "key-points",
+      "sources",
+    ]);
+    expect(onValueChange).toHaveBeenNthCalledWith(3, ["sources"]);
+    expect(keyPoints).toHaveAttribute("aria-pressed", "false");
+    expect(sources).toHaveAttribute("aria-pressed", "true");
   });
 
   it("submits selected values via ChoiceSubmit in multiple mode", async () => {
@@ -86,10 +91,10 @@ describe("choice", () => {
 
     render(
       <Choice multiple onSubmit={onSubmit} submitOnSelect={false}>
-        <ChoiceQuestion>Select categories</ChoiceQuestion>
+        <ChoiceQuestion>What should the summary include?</ChoiceQuestion>
         <ChoiceOptions>
-          <ChoiceOption value="events">Events</ChoiceOption>
-          <ChoiceOption value="news">News</ChoiceOption>
+          <ChoiceOption value="key-points">Key points</ChoiceOption>
+          <ChoiceOption value="sources">Sources</ChoiceOption>
         </ChoiceOptions>
         <ChoiceSubmit />
       </Choice>
@@ -98,11 +103,11 @@ describe("choice", () => {
     const submit = screen.getByRole("button", { name: "Confirm (0)" });
     expect(submit).toBeDisabled();
 
-    await user.click(screen.getByRole("button", { name: "Events" }));
+    await user.click(screen.getByRole("button", { name: "Key points" }));
     expect(screen.getByRole("button", { name: "Confirm (1)" })).toBeEnabled();
 
     await user.click(screen.getByRole("button", { name: "Confirm (1)" }));
-    expect(onSubmit).toHaveBeenCalledWith(["events"]);
+    expect(onSubmit).toHaveBeenCalledWith(["key-points"]);
   });
 
   it("prevents interactions when disabled", async () => {
@@ -112,14 +117,14 @@ describe("choice", () => {
 
     render(
       <Choice disabled onSubmit={onSubmit} onValueChange={onValueChange}>
-        <ChoiceQuestion>Disabled question</ChoiceQuestion>
+        <ChoiceQuestion>Pick a format</ChoiceQuestion>
         <ChoiceOptions>
-          <ChoiceOption value="crime">Crime</ChoiceOption>
+          <ChoiceOption value="brief">Brief</ChoiceOption>
         </ChoiceOptions>
       </Choice>
     );
 
-    const button = screen.getByRole("button", { name: "Crime" });
+    const button = screen.getByRole("button", { name: "Brief" });
     expect(button).toBeDisabled();
     await user.click(button);
 

--- a/packages/elements/src/choice.tsx
+++ b/packages/elements/src/choice.tsx
@@ -210,7 +210,7 @@ export const ChoiceOption = ({
   } = useChoiceContext();
 
   const isSelected = selectedValues.includes(value);
-  const resolvedVariant = variant ?? (isSelected ? "default" : "outline");
+  const resolvedVariant = variant ?? (isSelected ? "secondary" : "outline");
 
   const handleClick = useCallback(
     (event: MouseEvent<HTMLButtonElement>) => {
@@ -231,7 +231,9 @@ export const ChoiceOption = ({
       aria-describedby={description ? descriptionId : undefined}
       aria-pressed={isSelected}
       className={cn(
-        "h-auto max-w-full justify-start rounded-full px-4 py-2 text-left whitespace-normal",
+        "cursor-pointer rounded-full px-4",
+        description &&
+          "h-auto py-2 max-w-full justify-start text-left whitespace-normal",
         className
       )}
       disabled={disabled || rootDisabled}
@@ -241,17 +243,19 @@ export const ChoiceOption = ({
       {...props}
       onClick={handleClick}
     >
-      <span className="flex flex-col items-start gap-1">
-        <span>{children ?? value}</span>
-        {description ? (
+      {description ? (
+        <span className="flex flex-col items-start gap-1">
+          <span>{children ?? value}</span>
           <span
             className="text-muted-foreground text-xs leading-snug"
             id={descriptionId}
           >
             {description}
           </span>
-        ) : null}
-      </span>
+        </span>
+      ) : (
+        (children ?? value)
+      )}
     </Button>
   );
 };

--- a/packages/examples/src/choice-multiple.tsx
+++ b/packages/examples/src/choice-multiple.tsx
@@ -10,6 +10,13 @@ import {
 } from "@repo/elements/choice";
 import { useCallback, useState } from "react";
 
+const labels: Record<string, string> = {
+  "key-points": "Key points",
+  "action-items": "Action items",
+  timeline: "Timeline",
+  sources: "Sources",
+};
+
 const Example = () => {
   const [selected, setSelected] = useState<string[]>([]);
   const handleSubmit = useCallback((value: string | string[]) => {
@@ -20,30 +27,43 @@ const Example = () => {
 
   return (
     <div className="w-full max-w-2xl space-y-3">
-      <Choice multiple onSubmit={handleSubmit} submitOnSelect={false}>
-        <ChoiceQuestion>Which categories should we include?</ChoiceQuestion>
-        <ChoiceOptions>
-          <ChoiceOption description="Incidents and safety trends" value="crime">
-            Crime
-          </ChoiceOption>
-          <ChoiceOption description="Permits and construction" value="permits">
-            Permits
-          </ChoiceOption>
-          <ChoiceOption description="Neighborhood events" value="events">
-            Events
-          </ChoiceOption>
-          <ChoiceOption description="Local headlines" value="news">
-            News
-          </ChoiceOption>
-        </ChoiceOptions>
-        <ChoiceSubmit />
-      </Choice>
       {selected.length > 0 ? (
-        <ChoiceStatus>Selected: {selected.join(", ")}</ChoiceStatus>
-      ) : (
         <ChoiceStatus>
-          Select one or more categories, then confirm.
+          Includes: {selected.map((v) => labels[v]).join(", ")}
         </ChoiceStatus>
+      ) : (
+        <Choice multiple onSubmit={handleSubmit} submitOnSelect={false}>
+          <ChoiceQuestion>
+            What should the summary include?
+          </ChoiceQuestion>
+          <ChoiceOptions>
+            <ChoiceOption
+              description="Main takeaways and findings"
+              value="key-points"
+            >
+              Key points
+            </ChoiceOption>
+            <ChoiceOption
+              description="Next steps and follow-ups"
+              value="action-items"
+            >
+              Action items
+            </ChoiceOption>
+            <ChoiceOption
+              description="Key dates and milestones"
+              value="timeline"
+            >
+              Timeline
+            </ChoiceOption>
+            <ChoiceOption
+              description="References and citations"
+              value="sources"
+            >
+              Sources
+            </ChoiceOption>
+          </ChoiceOptions>
+          <ChoiceSubmit />
+        </Choice>
       )}
     </div>
   );

--- a/packages/examples/src/choice.tsx
+++ b/packages/examples/src/choice.tsx
@@ -9,6 +9,12 @@ import {
 } from "@repo/elements/choice";
 import { useCallback, useState } from "react";
 
+const labels: Record<string, string> = {
+  brief: "Brief",
+  standard: "Standard",
+  detailed: "Detailed",
+};
+
 const Example = () => {
   const [selected, setSelected] = useState<string>();
   const handleSubmit = useCallback((value: string | string[]) => {
@@ -19,27 +25,29 @@ const Example = () => {
 
   return (
     <div className="w-full max-w-2xl space-y-3">
-      <Choice onSubmit={handleSubmit}>
-        <ChoiceQuestion>How should I scope this briefing?</ChoiceQuestion>
-        <ChoiceOptions>
-          <ChoiceOption
-            description="Most recent 24 hours"
-            value="last-24-hours"
-          >
-            Last 24 hours
-          </ChoiceOption>
-          <ChoiceOption description="Past 7 days" value="last-week">
-            Last week
-          </ChoiceOption>
-          <ChoiceOption description="Past 30 days" value="last-month">
-            Last month
-          </ChoiceOption>
-        </ChoiceOptions>
-      </Choice>
       {selected ? (
-        <ChoiceStatus>Selected: {selected}</ChoiceStatus>
+        <ChoiceStatus>Response detail: {labels[selected]}</ChoiceStatus>
       ) : (
-        <ChoiceStatus>Choose one option to continue.</ChoiceStatus>
+        <Choice onSubmit={handleSubmit}>
+          <ChoiceQuestion>How detailed should the response be?</ChoiceQuestion>
+          <ChoiceOptions>
+            <ChoiceOption
+              description="A few sentences at most"
+              value="brief"
+            >
+              Brief
+            </ChoiceOption>
+            <ChoiceOption description="A balanced overview" value="standard">
+              Standard
+            </ChoiceOption>
+            <ChoiceOption
+              description="In-depth with examples"
+              value="detailed"
+            >
+              Detailed
+            </ChoiceOption>
+          </ChoiceOptions>
+        </Choice>
       )}
     </div>
   );


### PR DESCRIPTION
Adds a composable Choice component for AI workflows where the model needs user input before continuing, like  how Claude Code prompts users with askUserQuestion.

Supports both single-select (auto-submits on click) and multi-select (with a confirm button).

  - Component (packages/elements/src/choice.tsx): Six composable pieces — Choice, ChoiceQuestion, ChoiceOptions, ChoiceOption, ChoiceSubmit, ChoiceStatus
 
<img width="891" height="676" alt="Screenshot 2026-02-12 at 21 47 56" src="https://github.com/user-attachments/assets/49891557-c1aa-44ae-8df1-c0b9888d8d71" />
