### PR TITLE
fix: code block tab height

### DIFF
--- a/apps/docs/components/custom/preview.tsx
+++ b/apps/docs/components/custom/preview.tsx
@@ -60,7 +60,7 @@ export const Preview = async ({ path, className }: ComponentPreviewProps) => {
       <CodeBlockTab className="not-prose p-0" value="preview">
         <ResizablePanelGroup direction="horizontal" id={`preview-${path}`}>
           <ResizablePanel defaultSize={100}>
-            <div className={cn("h-[600px] overflow-auto p-4", className)}>
+            <div className={cn("max-h-[600px] overflow-auto p-4", className)}>
               <Component />
             </div>
           </ResizablePanel>


### PR DESCRIPTION
Fixes #375

The fix solves the height issue in the component docs where the preview container was using a fixed height instead of a max height. Nothing else was changed and everything works properly as earlier.