### PR TITLE
fix: move max-width to MessageContent for easier override

### DIFF
--- a/packages/elements/src/message.tsx
+++ b/packages/elements/src/message.tsx
@@ -38,7 +38,7 @@ export type MessageProps = HTMLAttributes<HTMLDivElement> & {
 export const Message = ({ className, from, ...props }: MessageProps) => (
   <div
     className={cn(
-      "group flex w-full max-w-[95%] flex-col gap-2",
+      "group flex w-full flex-col gap-2",
       from === "user" ? "is-user ml-auto justify-end" : "is-assistant",
       className
     )}
@@ -55,7 +55,7 @@ export const MessageContent = ({
 }: MessageContentProps) => (
   <div
     className={cn(
-      "is-user:dark flex w-fit min-w-0 max-w-full flex-col gap-2 overflow-hidden text-sm",
+      "is-user:dark flex w-fit min-w-0 max-w-[95%] flex-col gap-2 overflow-hidden text-sm",
       "group-[.is-user]:ml-auto group-[.is-user]:rounded-lg group-[.is-user]:bg-secondary group-[.is-user]:px-4 group-[.is-user]:py-3 group-[.is-user]:text-foreground",
       "group-[.is-assistant]:text-foreground",
       className


### PR DESCRIPTION
Recently I found the `max-w-[95%]` class on the `Message` component to be tedious to handle styling with, especially with `Tool` or `Confirmation` children.

This fix moves the max-width constraint down one level to `MessageContent`, making it easy to override for specific message children.

Shouldn't break anything, as `MessageContent` is used for basically everything anyway.