### PR TITLE
Remove invalid Shimmer fallback now that children text is required

### DIFF
--- a/.changeset/remove-shimmer-fallback.md
+++ b/.changeset/remove-shimmer-fallback.md
@@ -1,0 +1,5 @@
+---
+"ai-elements": patch
+---
+
+Remove invalid Shimmer fallback from TerminalStatus now that Shimmer requires children text

--- a/packages/elements/src/terminal.tsx
+++ b/packages/elements/src/terminal.tsx
@@ -16,7 +16,6 @@ import {
   useState,
 } from "react";
 
-import { Shimmer } from "./shimmer";
 
 interface TerminalContextType {
   output: string;


### PR DESCRIPTION
## Context

After updating `ai-elements`, I discovered a typechecking issue.
Now that the `Shimmer` component requires a string children to be passed, the fallback in `TerminalStatus` is no longer valid.