### PR TITLE
fix(docs): correct "Edit on GitHub" links for components and examples

### DIFF
--- a/apps/docs/app/[lang]/components/[[...slug]]/page.tsx
+++ b/apps/docs/app/[lang]/components/[[...slug]]/page.tsx
@@ -47,7 +47,7 @@ const Page = async ({
         footer: (
           <div className="my-3 space-y-3">
             <Separator />
-            <EditSource path={page.path} />
+            <EditSource path={page.path} contentDir="components" />
             <ScrollTop />
             <Feedback />
             <CopyPage text={markdown} />

--- a/apps/docs/app/[lang]/docs/[[...slug]]/page.tsx
+++ b/apps/docs/app/[lang]/docs/[[...slug]]/page.tsx
@@ -41,7 +41,7 @@ const Page = async ({ params }: PageProps<"/[lang]/docs/[[...slug]]">) => {
         footer: (
           <div className="my-3 space-y-3">
             <Separator />
-            <EditSource path={page.path} />
+            <EditSource path={page.path} contentDir="docs" />
             <ScrollTop />
             <Feedback />
             <CopyPage text={markdown} />

--- a/apps/docs/app/[lang]/examples/[[...slug]]/page.tsx
+++ b/apps/docs/app/[lang]/examples/[[...slug]]/page.tsx
@@ -45,7 +45,7 @@ const Page = async ({ params }: PageProps<"/[lang]/examples/[[...slug]]">) => {
         footer: (
           <div className="my-3 space-y-3">
             <Separator />
-            <EditSource path={page.path} />
+            <EditSource path={page.path} contentDir="examples" />
             <ScrollTop />
             <Feedback />
             <CopyPage text={markdown} />

--- a/apps/docs/components/geistdocs/edit-source.tsx
+++ b/apps/docs/components/geistdocs/edit-source.tsx
@@ -4,13 +4,14 @@ import { github } from "@/geistdocs";
 
 interface EditSourceProps {
   path: string | undefined;
+  contentDir?: string;
 }
 
-export const EditSource = ({ path }: EditSourceProps) => {
+export const EditSource = ({ path, contentDir = "docs" }: EditSourceProps) => {
   let url: string | undefined;
 
   if (github.owner && github.repo && path) {
-    url = `https://github.com/${github.owner}/${github.repo}/edit/main/apps/docs/content/docs/${path}`;
+    url = `https://github.com/${github.owner}/${github.repo}/edit/main/apps/docs/content/${contentDir}/${path}`;
   }
 
   if (!url) {


### PR DESCRIPTION
## Recreate
1. Go to any /components page like https://elements.ai-sdk.dev/components/attachments
2. Click "Edit this page on GitHub"
3. 404

## Summary
- The `EditSource` component hardcoded `content/docs/` in the GitHub edit URL, causing 404s for `/components/*` and `/examples/*` pages
- Added a `contentDir` prop to `EditSource` so each page section passes its correct content directory (`docs`, `components`, or `examples`)
- `/docs/*` pages are unaffected (uses `"docs"` as the default)
