### PR TITLE
tool: enable custom icons

### DIFF
--- a/apps/docs/content/components/(chatbot)/tool.mdx
+++ b/apps/docs/content/components/(chatbot)/tool.mdx
@@ -176,6 +176,7 @@ export async function POST(req: Request) {
 ## Features
 
 - Collapsible interface for showing/hiding tool details
+- Customizable tool icons, with support for mapping icons by tool name
 - Visual status indicators with icons and badges
 - Support for multiple tool execution states (pending, running, completed, error)
 - Formatted parameter display with JSON syntax highlighting
@@ -211,6 +212,19 @@ Shows a tool that encountered an error during execution. Opens by default to dis
 
 <Preview path="tool-output-error" />
 
+### Custom Icons
+
+Pass a function to the `icon` prop to render a custom icon. The function receives an object with:
+
+- `type`: the tool part type
+- `state`: the current execution state
+- `toolName`: the derived tool name
+- `className`: default sizing and color styles
+
+Use `toolName` to map different icons by tool type. When the function returns `null`, the default wrench icon is used.
+
+<Preview path="tool-custom-icons" />
+
 ## Props
 
 ### `<Tool />`
@@ -229,6 +243,10 @@ Shows a tool that encountered an error during execution. Opens by default to dis
 
 <TypeTable
   type={{
+    icon: {
+      description: "Custom icon for the tool header. Pass a ReactNode for a static icon, or a function that receives a ToolIconProps object and returns a ReactNode.",
+      type: "ReactNode | ((props: ToolIconProps) => ReactNode)",
+    },
     title: {
       description: "Custom title to display instead of the derived tool name.",
       type: "string",

--- a/packages/elements/src/tool.tsx
+++ b/packages/elements/src/tool.tsx
@@ -1,5 +1,8 @@
 "use client";
 
+import type { DynamicToolUIPart, ToolUIPart } from "ai";
+import type { ComponentProps, ReactNode } from "react";
+
 import { Badge } from "@repo/shadcn-ui/components/ui/badge";
 import {
   Collapsible,
@@ -7,7 +10,6 @@ import {
   CollapsibleTrigger,
 } from "@repo/shadcn-ui/components/ui/collapsible";
 import { cn } from "@repo/shadcn-ui/lib/utils";
-import type { DynamicToolUIPart, ToolUIPart } from "ai";
 import {
   CheckCircleIcon,
   ChevronDownIcon,
@@ -16,7 +18,6 @@ import {
   WrenchIcon,
   XCircleIcon,
 } from "lucide-react";
-import type { ComponentProps, ReactNode } from "react";
 import { isValidElement } from "react";
 
 import { CodeBlock } from "./code-block";
@@ -32,17 +33,22 @@ export const Tool = ({ className, ...props }: ToolProps) => (
 
 export type ToolPart = ToolUIPart | DynamicToolUIPart;
 
-export type ToolHeaderProps = {
+type ToolPartProps =
+  | (Pick<ToolUIPart, "type" | "state"> & { toolName?: never })
+  | Pick<DynamicToolUIPart, "type" | "state" | "toolName">;
+
+export type ToolIconProps = {
+  type: ToolPart["type"];
+  state: ToolPart["state"];
+  toolName: string;
+  className: string;
+};
+
+export type ToolHeaderProps = ToolPartProps & {
+  icon?: ReactNode | ((props: ToolIconProps) => ReactNode);
   title?: string;
   className?: string;
-} & (
-  | { type: ToolUIPart["type"]; state: ToolUIPart["state"]; toolName?: never }
-  | {
-      type: DynamicToolUIPart["type"];
-      state: DynamicToolUIPart["state"];
-      toolName: string;
-    }
-);
+};
 
 const statusLabels: Record<ToolPart["state"], string> = {
   "approval-requested": "Awaiting Approval",
@@ -73,6 +79,7 @@ export const getStatusBadge = (status: ToolPart["state"]) => (
 
 export const ToolHeader = ({
   className,
+  icon,
   title,
   type,
   state,
@@ -81,6 +88,12 @@ export const ToolHeader = ({
 }: ToolHeaderProps) => {
   const derivedName =
     type === "dynamic-tool" ? toolName : type.split("-").slice(1).join("-");
+
+  const iconClassName = "size-4 shrink-0 text-muted-foreground";
+  const resolvedIcon =
+    typeof icon === "function"
+      ? icon({ type, state, toolName: derivedName, className: iconClassName })
+      : icon;
 
   return (
     <CollapsibleTrigger
@@ -91,7 +104,7 @@ export const ToolHeader = ({
       {...props}
     >
       <div className="flex items-center gap-2">
-        <WrenchIcon className="size-4 text-muted-foreground" />
+        {resolvedIcon ?? <WrenchIcon className={iconClassName} />}
         <span className="font-medium text-sm">{title ?? derivedName}</span>
         {getStatusBadge(state)}
       </div>

--- a/packages/elements/src/tool.tsx
+++ b/packages/elements/src/tool.tsx
@@ -33,10 +33,6 @@ export const Tool = ({ className, ...props }: ToolProps) => (
 
 export type ToolPart = ToolUIPart | DynamicToolUIPart;
 
-type ToolPartProps =
-  | (Pick<ToolUIPart, "type" | "state"> & { toolName?: never })
-  | Pick<DynamicToolUIPart, "type" | "state" | "toolName">;
-
 export type ToolIconProps = {
   type: ToolPart["type"];
   state: ToolPart["state"];
@@ -44,11 +40,18 @@ export type ToolIconProps = {
   className: string;
 };
 
-export type ToolHeaderProps = ToolPartProps & {
+export type ToolHeaderProps = {
   icon?: ReactNode | ((props: ToolIconProps) => ReactNode);
   title?: string;
   className?: string;
-};
+} & (
+  | { type: ToolUIPart["type"]; state: ToolUIPart["state"]; toolName?: never }
+  | {
+      type: DynamicToolUIPart["type"];
+      state: DynamicToolUIPart["state"];
+      toolName: string;
+    }
+);
 
 const statusLabels: Record<ToolPart["state"], string> = {
   "approval-requested": "Awaiting Approval",

--- a/packages/examples/src/tool-custom-icons.tsx
+++ b/packages/examples/src/tool-custom-icons.tsx
@@ -1,0 +1,76 @@
+"use client";
+
+import type { ComponentProps, ReactNode } from "react";
+import { Tool, ToolContent, ToolHeader, ToolInput } from "@repo/elements/tool";
+
+type SvgProps = ComponentProps<"svg">;
+
+const DatabaseIcon = (props: SvgProps) => (
+  <svg fill="none" stroke="currentColor" strokeWidth={2} viewBox="0 0 24 24" {...props}>
+    <ellipse cx="12" cy="6" rx="8" ry="3" />
+    <path d="M4 6v6c0 1.657 3.582 3 8 3s8-1.343 8-3V6" />
+    <path d="M4 12v6c0 1.657 3.582 3 8 3s8-1.343 8-3v-6" />
+  </svg>
+);
+
+const SearchIcon = (props: SvgProps) => (
+  <svg fill="none" stroke="currentColor" strokeWidth={2} viewBox="0 0 24 24" {...props}>
+    <circle cx="11" cy="11" r="8" />
+    <path d="m21 21-4.3-4.3" />
+  </svg>
+);
+
+const toolIcons: Record<string, (props: SvgProps) => ReactNode> = {
+  database_query: DatabaseIcon,
+  web_search: SearchIcon,
+};
+
+const renderIcon = ({ toolName, className }: { toolName: string; className: string }) => {
+  const Icon = toolIcons[toolName];
+  return Icon ? <Icon className={className} /> : null;
+};
+
+const Example = () => (
+  <div className="space-y-4">
+    <Tool>
+      <ToolHeader
+        icon={({ className }) => <DatabaseIcon className={className} />}
+        state="output-available"
+        title="database_query"
+        type="tool-database_query"
+      />
+      <ToolContent>
+        <ToolInput
+          input={{
+            query: "SELECT COUNT(*) FROM users WHERE created_at >= ?",
+            params: ["2024-01-01"],
+          }}
+        />
+      </ToolContent>
+    </Tool>
+    <Tool>
+      <ToolHeader
+        icon={renderIcon}
+        state="output-available"
+        title="web_search"
+        type="tool-web_search"
+      />
+      <ToolContent>
+        <ToolInput input={{ query: "latest AI news" }} />
+      </ToolContent>
+    </Tool>
+    <Tool>
+      <ToolHeader
+        icon={renderIcon}
+        state="output-available"
+        title="unknown_tool"
+        type="tool-unknown_tool"
+      />
+      <ToolContent>
+        <ToolInput input={{ foo: "bar" }} />
+      </ToolContent>
+    </Tool>
+  </div>
+);
+
+export default Example;

--- a/packages/examples/src/tool-custom-icons.tsx
+++ b/packages/examples/src/tool-custom-icons.tsx
@@ -2,13 +2,13 @@
 
 import type { ReactNode } from "react";
 import { Tool, ToolContent, ToolHeader, ToolInput } from "@repo/elements/tool";
-import { DatabaseIcon, GlobeIcon, SearchIcon } from "lucide-react";
+import { cn } from "@repo/shadcn-ui/lib/utils";
+import { DatabaseIcon, SearchIcon, WrenchIcon } from "lucide-react";
 import type { LucideProps } from "lucide-react";
 
 const toolIcons: Record<string, (props: LucideProps) => ReactNode> = {
   database_query: DatabaseIcon,
   web_search: SearchIcon,
-  browse_url: GlobeIcon,
 };
 
 const renderIcon = ({ toolName, className }: { toolName: string; className: string }) => {
@@ -20,7 +20,7 @@ const Example = () => (
   <div className="space-y-4">
     <Tool>
       <ToolHeader
-        icon={({ className }) => <DatabaseIcon className={className} />}
+        icon={renderIcon}
         state="output-available"
         title="database_query"
         type="tool-database_query"
@@ -47,15 +47,17 @@ const Example = () => (
     </Tool>
     <Tool>
       <ToolHeader
-        icon={({ className }) => (
-          <SearchIcon className={`${className} text-blue-500`} />
-        )}
-        state="output-available"
-        title="custom_search"
-        type="tool-custom_search"
+        icon={<WrenchIcon className="size-4 shrink-0 text-foreground" />}
+        state="input-available"
+        title="custom_style"
+        type="tool-custom_style"
       />
       <ToolContent>
-        <ToolInput input={{ query: "custom styled icon" }} />
+        <ToolInput
+          input={{
+            query: "SELECT COUNT(*) FROM large_table",
+          }}
+        />
       </ToolContent>
     </Tool>
     <Tool>

--- a/packages/examples/src/tool-custom-icons.tsx
+++ b/packages/examples/src/tool-custom-icons.tsx
@@ -1,28 +1,14 @@
 "use client";
 
-import type { ComponentProps, ReactNode } from "react";
+import type { ReactNode } from "react";
 import { Tool, ToolContent, ToolHeader, ToolInput } from "@repo/elements/tool";
+import { DatabaseIcon, GlobeIcon, SearchIcon } from "lucide-react";
+import type { LucideProps } from "lucide-react";
 
-type SvgProps = ComponentProps<"svg">;
-
-const DatabaseIcon = (props: SvgProps) => (
-  <svg fill="none" stroke="currentColor" strokeWidth={2} viewBox="0 0 24 24" {...props}>
-    <ellipse cx="12" cy="6" rx="8" ry="3" />
-    <path d="M4 6v6c0 1.657 3.582 3 8 3s8-1.343 8-3V6" />
-    <path d="M4 12v6c0 1.657 3.582 3 8 3s8-1.343 8-3v-6" />
-  </svg>
-);
-
-const SearchIcon = (props: SvgProps) => (
-  <svg fill="none" stroke="currentColor" strokeWidth={2} viewBox="0 0 24 24" {...props}>
-    <circle cx="11" cy="11" r="8" />
-    <path d="m21 21-4.3-4.3" />
-  </svg>
-);
-
-const toolIcons: Record<string, (props: SvgProps) => ReactNode> = {
+const toolIcons: Record<string, (props: LucideProps) => ReactNode> = {
   database_query: DatabaseIcon,
   web_search: SearchIcon,
+  browse_url: GlobeIcon,
 };
 
 const renderIcon = ({ toolName, className }: { toolName: string; className: string }) => {
@@ -57,6 +43,19 @@ const Example = () => (
       />
       <ToolContent>
         <ToolInput input={{ query: "latest AI news" }} />
+      </ToolContent>
+    </Tool>
+    <Tool>
+      <ToolHeader
+        icon={({ className }) => (
+          <SearchIcon className={`${className} text-blue-500`} />
+        )}
+        state="output-available"
+        title="custom_search"
+        type="tool-custom_search"
+      />
+      <ToolContent>
+        <ToolInput input={{ query: "custom styled icon" }} />
       </ToolContent>
     </Tool>
     <Tool>


### PR DESCRIPTION
Adds a customizable `icon` prop to `ToolHeader`, allowing users to replace the default wrench icon with custom icons, either statically or dynamically based on tool name and state.

## Changes

- Adds `icon` prop to `ToolHeaderProps` accepting a `ReactNode` or a render function `(props: ToolIconProps) => ReactNode`
- The render function receives `{ type, state, toolName, className }` — providing full tool context and default sizing/color styles via `className`
- Extracts `ToolPartProps` as a shared base type for both `ToolHeaderProps` and `ToolIconProps`
- Exports `ToolIconProps` so consumers can type their icon render functions
- Falls back to the default `WrenchIcon` when `icon` is not provided or returns `null`
- Adds `shrink-0` to the default icon className to prevent flex shrinking

## Testing

Verified rendering in the docs dev server with custom SVG icons, name-based icon mapping, and fallback to default:

<img width="821" height="333" alt="Screenshot 2026-03-15 at 12 26 00" src="https://github.com/user-attachments/assets/cd78b65c-5c36-4298-ba32-ddcb032e8167" />

