### PR TITLE
fix: correct attachment link in prompt-input docs

### DIFF
--- a/apps/docs/content/components/(chatbot)/prompt-input.mdx
+++ b/apps/docs/content/components/(chatbot)/prompt-input.mdx
@@ -478,7 +478,7 @@ Buttons can display tooltips with optional keyboard shortcut hints. Hover over t
 
 ### Attachments
 
-Attachment components have been moved to a separate module. See the [Attachment](/components/attachment) component documentation for details on `<Attachments />`, `<Attachment />`, `<AttachmentPreview />`, `<AttachmentInfo />`, and `<AttachmentRemove />`.
+Attachment components have been moved to a separate module. See the [Attachment](/components/attachments) component documentation for details on `<Attachments />`, `<Attachment />`, `<AttachmentPreview />`, `<AttachmentInfo />`, and `<AttachmentRemove />`.
 
 ### `<PromptInputActionMenu />`
 


### PR DESCRIPTION
## Fix broken link for Attachment component in prompt-input docs

### What
Fixes an incorrect link in the Attachments section of the `prompt-input` documentation.

**Before:** `/components/attachment`
**After:** `/components/attachments`

### Why
The link was pointing to a non-existent route (`/components/attachment`) instead of the correct one (`/components/attachments`), causing a broken navigation experience for users trying to find the Attachment component docs from the prompt-input page.

### Changes
- `apps/docs/content/components/(chatbot)/prompt-input.mdx` — updated the hyperlink in the Attachments section to use the correct plural path (`/components/attachments`)

### Testing
- Verified the corrected link navigates to the Attachment component documentation as expected