### PR TITLE
Fix #398: Support additional icon libraries (similar to shadcn/ui)?

### DIFF
--- a/packages/elements/src/artifact.tsx
+++ b/packages/elements/src/artifact.tsx
@@ -8,9 +8,8 @@ import {
   TooltipTrigger,
 } from "@repo/shadcn-ui/components/ui/tooltip";
 import { cn } from "@repo/shadcn-ui/lib/utils";
-import type { LucideIcon } from "lucide-react";
 import { XIcon } from "lucide-react";
-import type { ComponentProps, HTMLAttributes } from "react";
+import type { ComponentProps, ComponentType, HTMLAttributes } from "react";
 
 export type ArtifactProps = HTMLAttributes<HTMLDivElement>;
 
@@ -93,7 +92,7 @@ export const ArtifactActions = ({
 export type ArtifactActionProps = ComponentProps<typeof Button> & {
   tooltip?: string;
   label?: string;
-  icon?: LucideIcon;
+  icon?: ComponentType<{ className?: string }>;
 };
 
 export const ArtifactAction = ({

--- a/packages/elements/src/chain-of-thought.tsx
+++ b/packages/elements/src/chain-of-thought.tsx
@@ -8,9 +8,8 @@ import {
   CollapsibleTrigger,
 } from "@repo/shadcn-ui/components/ui/collapsible";
 import { cn } from "@repo/shadcn-ui/lib/utils";
-import type { LucideIcon } from "lucide-react";
 import { BrainIcon, ChevronDownIcon, DotIcon } from "lucide-react";
-import type { ComponentProps, ReactNode } from "react";
+import type { ComponentProps, ComponentType, ReactNode } from "react";
 import { createContext, memo, useContext, useMemo } from "react";
 
 interface ChainOfThoughtContextValue {
@@ -102,7 +101,7 @@ export const ChainOfThoughtHeader = memo(
 );
 
 export type ChainOfThoughtStepProps = ComponentProps<"div"> & {
-  icon?: LucideIcon;
+  icon?: ComponentType<{ className?: string }>;
   label: ReactNode;
   description?: ReactNode;
   status?: "complete" | "active" | "pending";

--- a/packages/elements/src/checkpoint.tsx
+++ b/packages/elements/src/checkpoint.tsx
@@ -8,9 +8,8 @@ import {
   TooltipTrigger,
 } from "@repo/shadcn-ui/components/ui/tooltip";
 import { cn } from "@repo/shadcn-ui/lib/utils";
-import type { LucideProps } from "lucide-react";
 import { BookmarkIcon } from "lucide-react";
-import type { ComponentProps, HTMLAttributes } from "react";
+import type { ComponentProps, HTMLAttributes, SVGProps } from "react";
 
 export type CheckpointProps = HTMLAttributes<HTMLDivElement>;
 
@@ -31,7 +30,7 @@ export const Checkpoint = ({
   </div>
 );
 
-export type CheckpointIconProps = LucideProps;
+export type CheckpointIconProps = SVGProps<SVGSVGElement>;
 
 export const CheckpointIcon = ({
   className,


### PR DESCRIPTION
Closes #398

Replaces the `LucideIcon`/`LucideProps` type constraints with generic React component types so callers can pass icons from any library — Tabler, Phosphor, Hugeicons, Remix, etc. — not just Lucide. The change is purely a type-level loosening; no runtime behavior changes.

- `artifact.tsx` — `ArtifactActionProps.icon` changed from `LucideIcon` to `ComponentType<{ className?: string }>`
- `chain-of-thought.tsx` — `ChainOfThoughtStepProps.icon` changed from `LucideIcon` to `ComponentType<{ className?: string }>`
- `checkpoint.tsx` — `CheckpointIconProps` changed from `LucideProps` to `SVGProps<SVGSVGElement>`

Verified by passing a Tabler icon (`IconBrain` from `@tabler/icons-react`) and a Phosphor icon (`Brain` from `phosphor-react`) into `ChainOfThoughtStep` and `ArtifactAction` respectively — both rendered correctly with no TypeScript errors.

---
*This PR was created with AI assistance (Claude). The changes were reviewed by quality gates and a critic model before submission.*