### PR TITLE
fix(elements): render empty tool output

### DIFF
--- a/packages/elements/__tests__/tool.test.tsx
+++ b/packages/elements/__tests__/tool.test.tsx
@@ -241,6 +241,15 @@ describe("toolOutput", () => {
     expect(container.textContent).toBe("");
   });
 
+  it("renders an empty string output", () => {
+    render(
+      <Tool>
+        <ToolOutput errorText={undefined} output="" />
+      </Tool>
+    );
+    expect(screen.getByText("Result")).toBeInTheDocument();
+  });
+
   it("renders object output as JSON", () => {
     const output = { data: [1, 2, 3], result: "success" };
     render(

--- a/packages/elements/src/tool.tsx
+++ b/packages/elements/src/tool.tsx
@@ -138,7 +138,7 @@ export const ToolOutput = ({
   errorText,
   ...props
 }: ToolOutputProps) => {
-  if (!(output || errorText)) {
+  if (output == null && !errorText) {
     return null;
   }
 


### PR DESCRIPTION
## Summary
- Treats only `null` and `undefined` as missing tool output
- Adds regression coverage so empty string tool results still render the result section

Fixes #399.

## Verification
- pnpm --filter @repo/elements test __tests__/tool.test.tsx