### PR TITLE
docs(speech-input): keep transcription keys server-side

### DIFF
--- a/apps/docs/content/components/(voice)/speech-input.mdx
+++ b/apps/docs/content/components/(voice)/speech-input.mdx
@@ -131,24 +131,17 @@ For full cross-browser support, provide the `onAudioRecorded` callback that send
 
 ## Usage with MediaRecorder Fallback
 
-To support Firefox and Safari, provide an `onAudioRecorded` callback that sends audio to a transcription service:
+To support Firefox and Safari, provide an `onAudioRecorded` callback that sends audio to an application-owned route. Keep provider API keys on the server, not in client components or `NEXT_PUBLIC_*` environment variables.
 
 ```tsx
 const handleAudioRecorded = async (audioBlob: Blob): Promise<string> => {
   const formData = new FormData();
   formData.append("file", audioBlob, "audio.webm");
-  formData.append("model", "whisper-1");
 
-  const response = await fetch(
-    "https://api.openai.com/v1/audio/transcriptions",
-    {
-      method: "POST",
-      headers: {
-        Authorization: `Bearer ${process.env.OPENAI_API_KEY}`,
-      },
-      body: formData,
-    }
-  );
+  const response = await fetch("/api/transcribe", {
+    body: formData,
+    method: "POST",
+  });
 
   const data = await response.json();
   return data.text;
@@ -158,6 +151,36 @@ const handleAudioRecorded = async (audioBlob: Blob): Promise<string> => {
   onTranscriptionChange={(text) => console.log(text)}
   onAudioRecorded={handleAudioRecorded}
 />;
+```
+
+Then proxy the request from your server route to your transcription provider:
+
+```ts title="app/api/transcribe/route.ts"
+export async function POST(req: Request) {
+  const formData = await req.formData();
+  formData.set("model", "whisper-1");
+
+  const response = await fetch(
+    "https://api.openai.com/v1/audio/transcriptions",
+    {
+      body: formData,
+      headers: {
+        Authorization: `Bearer ${process.env.OPENAI_API_KEY}`,
+      },
+      method: "POST",
+    }
+  );
+
+  if (!response.ok) {
+    return Response.json(
+      { error: "Transcription failed" },
+      { status: response.status }
+    );
+  }
+
+  const data = await response.json();
+  return Response.json({ text: data.text });
+}
 ```
 
 ## Notes

--- a/packages/examples/src/speech-input.tsx
+++ b/packages/examples/src/speech-input.tsx
@@ -5,24 +5,17 @@ import { useCallback, useState } from "react";
 
 /**
  * Fallback handler for browsers that don't support Web Speech API (Firefox, Safari).
- * This function receives recorded audio and should send it to a transcription service.
- * Example uses OpenAI Whisper API - replace with your preferred service.
+ * This function receives recorded audio and sends it to an app-owned server route.
+ * Keep provider API keys on the server; do not expose them in client components.
  */
 const handleAudioRecorded = async (audioBlob: Blob): Promise<string> => {
   const formData = new FormData();
   formData.append("file", audioBlob, "audio.webm");
-  formData.append("model", "whisper-1");
 
-  const response = await fetch(
-    "https://api.openai.com/v1/audio/transcriptions",
-    {
-      body: formData,
-      headers: {
-        Authorization: `Bearer ${process.env.NEXT_PUBLIC_OPENAI_API_KEY}`,
-      },
-      method: "POST",
-    }
-  );
+  const response = await fetch("/api/transcribe", {
+    body: formData,
+    method: "POST",
+  });
 
   if (!response.ok) {
     throw new Error("Transcription failed");

--- a/skills/ai-elements/references/speech-input.md
+++ b/skills/ai-elements/references/speech-input.md
@@ -110,24 +110,17 @@ For full cross-browser support, provide the `onAudioRecorded` callback that send
 
 ## Usage with MediaRecorder Fallback
 
-To support Firefox and Safari, provide an `onAudioRecorded` callback that sends audio to a transcription service:
+To support Firefox and Safari, provide an `onAudioRecorded` callback that sends audio to an application-owned route. Keep provider API keys on the server, not in client components or `NEXT_PUBLIC_*` environment variables.
 
 ```tsx
 const handleAudioRecorded = async (audioBlob: Blob): Promise<string> => {
   const formData = new FormData();
   formData.append("file", audioBlob, "audio.webm");
-  formData.append("model", "whisper-1");
 
-  const response = await fetch(
-    "https://api.openai.com/v1/audio/transcriptions",
-    {
-      method: "POST",
-      headers: {
-        Authorization: `Bearer ${process.env.OPENAI_API_KEY}`,
-      },
-      body: formData,
-    }
-  );
+  const response = await fetch("/api/transcribe", {
+    body: formData,
+    method: "POST",
+  });
 
   const data = await response.json();
   return data.text;
@@ -137,6 +130,36 @@ const handleAudioRecorded = async (audioBlob: Blob): Promise<string> => {
   onTranscriptionChange={(text) => console.log(text)}
   onAudioRecorded={handleAudioRecorded}
 />;
+```
+
+Then proxy the request from your server route to your transcription provider:
+
+```ts title="app/api/transcribe/route.ts"
+export async function POST(req: Request) {
+  const formData = await req.formData();
+  formData.set("model", "whisper-1");
+
+  const response = await fetch(
+    "https://api.openai.com/v1/audio/transcriptions",
+    {
+      body: formData,
+      headers: {
+        Authorization: `Bearer ${process.env.OPENAI_API_KEY}`,
+      },
+      method: "POST",
+    }
+  );
+
+  if (!response.ok) {
+    return Response.json(
+      { error: "Transcription failed" },
+      { status: response.status }
+    );
+  }
+
+  const data = await response.json();
+  return Response.json({ text: data.text });
+}
 ```
 
 ## Notes

--- a/skills/ai-elements/scripts/speech-input.tsx
+++ b/skills/ai-elements/scripts/speech-input.tsx
@@ -5,24 +5,17 @@ import { useCallback, useState } from "react";
 
 /**
  * Fallback handler for browsers that don't support Web Speech API (Firefox, Safari).
- * This function receives recorded audio and should send it to a transcription service.
- * Example uses OpenAI Whisper API - replace with your preferred service.
+ * This function receives recorded audio and sends it to an app-owned server route.
+ * Keep provider API keys on the server; do not expose them in client components.
  */
 const handleAudioRecorded = async (audioBlob: Blob): Promise<string> => {
   const formData = new FormData();
   formData.append("file", audioBlob, "audio.webm");
-  formData.append("model", "whisper-1");
 
-  const response = await fetch(
-    "https://api.openai.com/v1/audio/transcriptions",
-    {
-      body: formData,
-      headers: {
-        Authorization: `Bearer ${process.env.NEXT_PUBLIC_OPENAI_API_KEY}`,
-      },
-      method: "POST",
-    }
-  );
+  const response = await fetch("/api/transcribe", {
+    body: formData,
+    method: "POST",
+  });
 
   if (!response.ok) {
     throw new Error("Transcription failed");


### PR DESCRIPTION
## Summary
- change the SpeechInput fallback examples to post recorded audio to an app-owned /api/transcribe route
- add a server route example that keeps the provider API key on the server
- update the package example and generated skill reference to avoid NEXT_PUBLIC provider secrets

Fixes #422

## Verification
- git diff --check
- pnpm --filter @repo/elements test __tests__/speech-input.test.tsx