### PR TITLE
Add virtualized conversation content

### DIFF
--- a/apps/docs/content/components/(chatbot)/conversation.mdx
+++ b/apps/docs/content/components/(chatbot)/conversation.mdx
@@ -27,6 +27,7 @@ import {
   ConversationDownload,
   ConversationEmptyState,
   ConversationScrollButton,
+  ConversationVirtualizedContent,
 } from "@/components/ai-elements/conversation";
 import {
   Message,
@@ -134,10 +135,40 @@ export async function POST(req: Request) {
 }
 ```
 
+## Virtualized Messages
+
+Use `ConversationVirtualizedContent` for long conversations. It keeps the regular `Conversation` auto-scroll behavior while only mounting the visible message rows.
+
+```tsx
+<Conversation>
+  <ConversationVirtualizedContent
+    items={messages}
+    estimateSize={() => 160}
+    getItemKey={(message) => message.id}
+  >
+    {(message) => (
+      <Message from={message.role}>
+        <MessageContent>
+          {message.parts.map((part, index) =>
+            part.type === "text" ? (
+              <MessageResponse key={`${message.id}-${index}`}>
+                {part.text}
+              </MessageResponse>
+            ) : null
+          )}
+        </MessageContent>
+      </Message>
+    )}
+  </ConversationVirtualizedContent>
+  <ConversationScrollButton />
+</Conversation>
+```
+
 ## Features
 
 - Automatic scrolling to the bottom when new messages are added
 - Smooth scrolling behavior with configurable animation
+- Virtualized message rendering for large conversations
 - Scroll button that appears when not at the bottom
 - Download conversation as Markdown
 - Responsive design with customizable padding and spacing
@@ -185,6 +216,50 @@ export async function POST(req: Request) {
     "...props": {
       description: "Any other props are spread to the root div.",
       type: 'Omit<React.HTMLAttributes<HTMLDivElement>, "children">',
+    },
+  }}
+/>
+
+### `<ConversationVirtualizedContent />`
+
+<TypeTable
+  type={{
+    items: {
+      description: "Array of items to virtualize.",
+      type: "TItem[]",
+      required: true,
+    },
+    children: {
+      description: "Render function for each virtualized item.",
+      type: "(item: TItem, index: number) => ReactNode",
+      required: true,
+    },
+    estimateSize: {
+      description: "Estimated pixel height for each item.",
+      type: "(item: TItem, index: number) => number",
+      default: "120",
+    },
+    getItemKey: {
+      description: "Optional stable key for each item.",
+      type: "(item: TItem, index: number) => Key",
+    },
+    gap: {
+      description: "Pixel gap between virtualized items.",
+      type: "number",
+      default: "32",
+    },
+    overscan: {
+      description: "Number of extra items to render outside the viewport.",
+      type: "number",
+      default: "8",
+    },
+    itemClassName: {
+      description: "Class name applied to each virtualized item wrapper.",
+      type: "string",
+    },
+    "...props": {
+      description: "Any other props are spread to the content div.",
+      type: 'Omit<ConversationContentProps, "children">',
     },
   }}
 />

--- a/packages/elements/__tests__/conversation.test.tsx
+++ b/packages/elements/__tests__/conversation.test.tsx
@@ -1,5 +1,7 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import { userEvent } from "@testing-library/user-event";
+import type * as StickToBottomModule from "use-stick-to-bottom";
+import type { StickToBottomContext } from "use-stick-to-bottom";
 
 import {
   Conversation,
@@ -7,63 +9,122 @@ import {
   ConversationDownload,
   ConversationEmptyState,
   ConversationScrollButton,
+  ConversationVirtualizedContent,
   messagesToMarkdown,
 } from "../src/conversation";
 
 // Mock use-stick-to-bottom with module-level state using vi.hoisted
 const {
-  mockState,
   mockScrollToBottom,
-  StickToBottomMock,
+  mockState,
+  getMockContext,
   StickToBottomContent,
+  StickToBottomMock,
 } = vi.hoisted(() => {
   const state = { isAtBottom: true };
   const scrollToBottom = vi.fn();
+  const stopScroll = vi.fn();
+  let targetScrollTop: unknown = null;
 
-  interface MockProps {
-    children?: React.ReactNode;
-    [key: string]: unknown;
+  // oxlint-disable-next-line eslint-plugin-unicorn(consistent-function-scoping)
+  const createRef = () => {
+    const ref = ((node: HTMLElement | null) => {
+      ref.current = node;
+    }) as React.MutableRefObject<HTMLElement | null> &
+      React.RefCallback<HTMLElement>;
+    ref.current = null;
+    return ref;
+  };
+
+  const scrollRef = createRef();
+  const contentRef = createRef();
+
+  const getContext = (): StickToBottomContext => ({
+    contentRef,
+    escapedFromLock: false,
+    isAtBottom: state.isAtBottom,
+    scrollRef,
+    scrollToBottom,
+    state: {
+      accumulated: 0,
+      calculatedTargetScrollTop: 0,
+      escapedFromLock: false,
+      isAtBottom: state.isAtBottom,
+      isNearBottom: true,
+      resizeDifference: 0,
+      scrollDifference: 0,
+      scrollTop: 0,
+      targetScrollTop: 0,
+      velocity: 0,
+    },
+    stopScroll,
+    get targetScrollTop() {
+      return targetScrollTop as StickToBottomContext["targetScrollTop"];
+    },
+    set targetScrollTop(value: StickToBottomContext["targetScrollTop"]) {
+      targetScrollTop = value;
+    },
+  });
+
+  interface MockProps extends Omit<
+    React.HTMLAttributes<HTMLDivElement>,
+    "children"
+  > {
+    children?:
+      | React.ReactNode
+      | ((context: StickToBottomContext) => React.ReactNode);
+  }
+
+  interface MockContentProps extends MockProps {
+    scrollClassName?: string;
   }
 
   // These components must be defined inside vi.hoisted() for mock setup
   // oxlint-disable-next-line eslint-plugin-unicorn(consistent-function-scoping)
   const StickyMock = ({ children, ...props }: MockProps) => (
     <div role="log" {...props}>
-      {children}
+      {typeof children === "function" ? children(getContext()) : children}
     </div>
   );
 
   // oxlint-disable-next-line eslint-plugin-unicorn(consistent-function-scoping)
-  const StickyContent = ({ children, ...props }: MockProps) => (
-    <div {...props}>{children}</div>
+  const StickyContent = ({
+    children,
+    scrollClassName,
+    ...props
+  }: MockContentProps) => (
+    <div
+      className={scrollClassName}
+      ref={scrollRef}
+      style={{ height: 400, overflow: "auto", width: 400 }}
+    >
+      <div {...props} ref={contentRef}>
+        {typeof children === "function" ? children(getContext()) : children}
+      </div>
+    </div>
   );
 
   return {
     StickToBottomContent: StickyContent,
     StickToBottomMock: StickyMock,
+    getMockContext: getContext,
     mockScrollToBottom: scrollToBottom,
     mockState: state,
   };
 });
 
-// oxlint-disable-next-line typescript-eslint(consistent-type-imports)
-vi.mock<typeof import("use-stick-to-bottom")>(
-  import("use-stick-to-bottom"),
-  () => {
-    const MockComponent = StickToBottomMock as typeof StickToBottomMock & {
-      Content: typeof StickToBottomContent;
-    };
-    MockComponent.Content = StickToBottomContent;
+vi.mock<typeof StickToBottomModule>(import("use-stick-to-bottom"), () => {
+  const MockComponent = StickToBottomMock as typeof StickToBottomMock & {
+    Content: typeof StickToBottomContent;
+  };
+  MockComponent.Content = StickToBottomContent;
 
-    return {
-      StickToBottom: MockComponent,
-      useStickToBottomContext: () => ({
-        isAtBottom: mockState.isAtBottom,
-        scrollToBottom: mockScrollToBottom,
-      }),
-    };
-  }
-);
+  return {
+    StickToBottom:
+      MockComponent as unknown as typeof StickToBottomModule.StickToBottom,
+    useStickToBottomContext: getMockContext,
+  };
+});
 
 // Custom format function for messagesToMarkdown test
 const customFormatMessage = (msg: {
@@ -114,6 +175,60 @@ describe("conversationContent", () => {
       </Conversation>
     );
     expect(screen.getByText("Content")).toBeInTheDocument();
+  });
+});
+
+const estimateVirtualizedMessageSize = () => 40;
+
+const getVirtualizedMessageKey = (item: { id: string }) => item.id;
+
+describe("conversationVirtualizedContent", () => {
+  const messages = Array.from({ length: 100 }, (_, index) => ({
+    content: `Message ${index}`,
+    id: `message-${index}`,
+  }));
+
+  it("renders visible items", async () => {
+    render(
+      <Conversation>
+        <ConversationVirtualizedContent
+          estimateSize={estimateVirtualizedMessageSize}
+          getItemKey={getVirtualizedMessageKey}
+          items={messages}
+          overscan={1}
+        >
+          {(item) => <div>{item.content}</div>}
+        </ConversationVirtualizedContent>
+      </Conversation>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Message 0")).toBeInTheDocument();
+    });
+
+    expect(screen.queryByText("Message 99")).not.toBeInTheDocument();
+  });
+
+  it("applies custom content and item class names", async () => {
+    const { container } = render(
+      <Conversation>
+        <ConversationVirtualizedContent
+          className="virtual-content"
+          estimateSize={estimateVirtualizedMessageSize}
+          itemClassName="virtual-item"
+          items={messages.slice(0, 3)}
+        >
+          {(item) => <div>{item.content}</div>}
+        </ConversationVirtualizedContent>
+      </Conversation>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Message 0")).toBeInTheDocument();
+    });
+
+    expect(container.querySelector(".virtual-content")).toBeInTheDocument();
+    expect(container.querySelector(".virtual-item")).toBeInTheDocument();
   });
 });
 
@@ -282,14 +397,7 @@ describe(messagesToMarkdown, () => {
       id: "multi",
       parts: [
         { text: "Hello ", type: "text" as const },
-        {
-          args: {},
-          result: {},
-          state: "result" as const,
-          toolInvocationId: "1",
-          toolName: "test",
-          type: "tool-invocation" as const,
-        },
+        { type: "step-start" as const },
         { text: "world", type: "text" as const },
       ],
       role: "assistant" as const,

--- a/packages/elements/package.json
+++ b/packages/elements/package.json
@@ -19,6 +19,7 @@
     "@streamdown/code": "^1.1.0",
     "@streamdown/math": "^1.0.2",
     "@streamdown/mermaid": "^1.0.2",
+    "@tanstack/react-virtual": "^3.13.24",
     "@xyflow/react": "^12.10.0",
     "ai": "^6.0.105",
     "ansi-to-react": "^6.2.6",

--- a/packages/elements/src/conversation.tsx
+++ b/packages/elements/src/conversation.tsx
@@ -2,9 +2,10 @@
 
 import { Button } from "@repo/shadcn-ui/components/ui/button";
 import { cn } from "@repo/shadcn-ui/lib/utils";
+import { useVirtualizer } from "@tanstack/react-virtual";
 import type { UIMessage } from "ai";
 import { ArrowDownIcon, DownloadIcon } from "lucide-react";
-import type { ComponentProps } from "react";
+import type { ComponentProps, Key, ReactNode } from "react";
 import { useCallback } from "react";
 import { StickToBottom, useStickToBottomContext } from "use-stick-to-bottom";
 
@@ -33,6 +34,91 @@ export const ConversationContent = ({
     {...props}
   />
 );
+
+export type ConversationVirtualizedContentProps<TItem> = Omit<
+  ConversationContentProps,
+  "children"
+> & {
+  items: TItem[];
+  children: (item: TItem, index: number) => ReactNode;
+  estimateSize?: (item: TItem, index: number) => number;
+  getItemKey?: (item: TItem, index: number) => Key;
+  gap?: number;
+  overscan?: number;
+  itemClassName?: string;
+};
+
+const DEFAULT_VIRTUALIZED_MESSAGE_SIZE = 120;
+const DEFAULT_VIRTUALIZED_MESSAGE_GAP = 32;
+const DEFAULT_VIRTUALIZED_OVERSCAN = 8;
+
+export const ConversationVirtualizedContent = <TItem,>({
+  className,
+  children,
+  estimateSize,
+  gap = DEFAULT_VIRTUALIZED_MESSAGE_GAP,
+  getItemKey,
+  itemClassName,
+  items,
+  overscan = DEFAULT_VIRTUALIZED_OVERSCAN,
+  ...props
+}: ConversationVirtualizedContentProps<TItem>) => {
+  const { scrollRef } = useStickToBottomContext();
+
+  const virtualizer = useVirtualizer<HTMLElement, HTMLDivElement>({
+    count: items.length,
+    estimateSize: (index) => {
+      const item = items[index];
+
+      if (item === undefined) {
+        return DEFAULT_VIRTUALIZED_MESSAGE_SIZE;
+      }
+
+      return estimateSize?.(item, index) ?? DEFAULT_VIRTUALIZED_MESSAGE_SIZE;
+    },
+    gap,
+    getItemKey: (index) => {
+      const item = items[index];
+      return item === undefined || !getItemKey
+        ? index
+        : getItemKey(item, index);
+    },
+    getScrollElement: () => scrollRef.current,
+    overscan,
+  });
+
+  return (
+    <StickToBottom.Content
+      className={cn("relative min-h-full p-4", className)}
+      {...props}
+    >
+      <div
+        className="relative w-full"
+        style={{ height: virtualizer.getTotalSize() }}
+      >
+        {virtualizer.getVirtualItems().map((virtualItem) => {
+          const item = items[virtualItem.index];
+
+          if (item === undefined) {
+            return null;
+          }
+
+          return (
+            <div
+              className={cn("absolute top-0 left-0 w-full", itemClassName)}
+              data-index={virtualItem.index}
+              key={virtualItem.key}
+              ref={virtualizer.measureElement}
+              style={{ transform: `translateY(${virtualItem.start}px)` }}
+            >
+              {children(item, virtualItem.index)}
+            </div>
+          );
+        })}
+      </div>
+    </StickToBottom.Content>
+  );
+};
 
 export type ConversationEmptyStateProps = ComponentProps<"div"> & {
   title?: string;

--- a/packages/examples/src/conversation.tsx
+++ b/packages/examples/src/conversation.tsx
@@ -6,6 +6,7 @@ import {
   ConversationDownload,
   ConversationEmptyState,
   ConversationScrollButton,
+  ConversationVirtualizedContent,
 } from "@repo/elements/conversation";
 import { Message, MessageContent } from "@repo/elements/message";
 import { MessageSquareIcon } from "lucide-react";
@@ -120,6 +121,10 @@ const messages: {
   },
 ];
 
+const estimateMessageSize = () => 72;
+
+const getMessageKey = (message: { key: string }) => message.key;
+
 const Example = () => {
   const [visibleMessages, setVisibleMessages] = useState<
     {
@@ -153,21 +158,27 @@ const Example = () => {
 
   return (
     <Conversation className="relative size-full">
-      <ConversationContent>
-        {visibleMessages.length === 0 ? (
+      {visibleMessages.length === 0 ? (
+        <ConversationContent>
           <ConversationEmptyState
             description="Messages will appear here as the conversation progresses."
             icon={<MessageSquareIcon className="size-6" />}
             title="Start a conversation"
           />
-        ) : (
-          visibleMessages.map(({ key, content, role }) => (
+        </ConversationContent>
+      ) : (
+        <ConversationVirtualizedContent
+          estimateSize={estimateMessageSize}
+          getItemKey={getMessageKey}
+          items={visibleMessages}
+        >
+          {({ key, content, role }) => (
             <Message from={role} key={key}>
               <MessageContent>{content}</MessageContent>
             </Message>
-          ))
-        )}
-      </ConversationContent>
+          )}
+        </ConversationVirtualizedContent>
+      )}
       <ConversationDownload messages={visibleMessages} />
       <ConversationScrollButton />
     </Conversation>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -224,6 +224,9 @@ importers:
       '@streamdown/mermaid':
         specifier: ^1.0.2
         version: 1.0.2(react@19.2.3)
+      '@tanstack/react-virtual':
+        specifier: ^3.13.24
+        version: 3.13.24(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@xyflow/react':
         specifier: ^12.10.0
         version: 12.10.0(@types/react@19.2.8)(immer@10.1.3)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -2721,6 +2724,15 @@ packages:
 
   '@tailwindcss/postcss@4.1.18':
     resolution: {integrity: sha512-Ce0GFnzAOuPyfV5SxjXGn0CubwGcuDB0zcdaPuCSzAa/2vII24JTkH+I6jcbXLb1ctjZMZZI6OjDaLPJQL1S0g==}
+
+  '@tanstack/react-virtual@3.13.24':
+    resolution: {integrity: sha512-aIJvz5OSkhNIhZIpYivrxrPTKYsjW9Uzy+sP/mx0S3sev2HyvPb7xmjbYvokzEpfgYHy/HjzJ2zFAETuUfgCpg==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  '@tanstack/virtual-core@3.14.0':
+    resolution: {integrity: sha512-JLANqGy/D6k4Ujmh8Tr25lGimuOXNiaVyXaCAZS0W+1390sADdGnyUdSWNIfd49gebtIxGMij4IktRVzrdr12Q==}
 
   '@testing-library/dom@10.4.1':
     resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
@@ -8926,6 +8938,14 @@ snapshots:
       '@tailwindcss/oxide': 4.1.18
       postcss: 8.5.6
       tailwindcss: 4.1.18
+
+  '@tanstack/react-virtual@3.13.24(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+    dependencies:
+      '@tanstack/virtual-core': 3.14.0
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+
+  '@tanstack/virtual-core@3.14.0': {}
 
   '@testing-library/dom@10.4.1':
     dependencies:


### PR DESCRIPTION
## Summary
- add an opt-in ConversationVirtualizedContent component backed by @tanstack/react-virtual
- reuse the existing use-stick-to-bottom scroll element so auto-scroll and the scroll button keep working in the same Conversation surface
- add tests for visible-row rendering and custom class names
- update the conversation docs and preview example with virtualized usage

Fixes #103.

## Testing
- pnpm --filter @repo/elements test
- pnpm exec oxlint packages/elements/src/conversation.tsx packages/elements/__tests__/conversation.test.tsx packages/examples/src/conversation.tsx
- pnpm exec oxfmt --check packages/elements/src/conversation.tsx packages/elements/__tests__/conversation.test.tsx packages/examples/src/conversation.tsx 'apps/docs/content/components/(chatbot)/conversation.mdx'
- git diff --check

## Notes
- I also ran pnpm run check. It currently stops on pre-existing formatting issues in apps/docs/content/components/(chatbot)/confirmation.mdx, apps/docs/content/components/(chatbot)/message.mdx, and apps/docs/package.json before reaching lint; those files are unrelated and left untouched.