### PR TITLE
fix(message): preserve sticky descendants

### DIFF
--- a/packages/elements/__tests__/message.test.tsx
+++ b/packages/elements/__tests__/message.test.tsx
@@ -71,6 +71,13 @@ describe("messageContent", () => {
     );
     expect(container.firstChild).toHaveClass("custom");
   });
+
+  it("clips horizontal overflow without hiding sticky descendants", () => {
+    const { container } = render(<MessageContent>Text</MessageContent>);
+
+    expect(container.firstChild).toHaveClass("overflow-x-clip");
+    expect(container.firstChild).not.toHaveClass("overflow-hidden");
+  });
 });
 
 describe("messageActions", () => {

--- a/packages/elements/src/message.tsx
+++ b/packages/elements/src/message.tsx
@@ -54,7 +54,7 @@ export const MessageContent = ({
 }: MessageContentProps) => (
   <div
     className={cn(
-      "is-user:dark flex w-fit min-w-0 max-w-full flex-col gap-2 overflow-hidden text-sm",
+      "is-user:dark flex w-fit min-w-0 max-w-full flex-col gap-2 overflow-x-clip text-sm",
       "group-[.is-user]:ml-auto group-[.is-user]:rounded-lg group-[.is-user]:bg-secondary group-[.is-user]:px-4 group-[.is-user]:py-3 group-[.is-user]:text-foreground",
       "group-[.is-assistant]:text-foreground",
       className


### PR DESCRIPTION
## Summary
- replace `MessageContent`'s `overflow-hidden` with `overflow-x-clip`
- preserve horizontal clipping without creating the vertical overflow behavior that breaks sticky descendants
- add a regression assertion for the rendered class list

Closes #420.

## Verification
- `pnpm install --frozen-lockfile`
- `pnpm --filter @repo/elements test -- message.test.tsx` (ran the browser test suite; 46 files / 951 tests passed)
- `git diff --check`

## Notes
- `pnpm check packages/elements/src/message.tsx packages/elements/__tests__/message.test.tsx` reports formatting is correct, then fails in oxlint config with `Rule 'no-unresolved' not found in plugin 'import'`.\n- `pnpm --filter @repo/elements exec tsc --noEmit` fails on existing upstream test typing errors unrelated to this change, including the pre-existing `MessageContent variant` test props and several other test mocks.