### PR TITLE
Remove duplicated type definition

### DIFF
--- a/packages/elements/src/confirmation.tsx
+++ b/packages/elements/src/confirmation.tsx
@@ -25,11 +25,6 @@ type ToolUIPartApproval =
     }
   | {
       id: string;
-      approved: true;
-      reason?: string;
-    }
-  | {
-      id: string;
       approved: false;
       reason?: string;
     }


### PR DESCRIPTION
Simple fix of removing a duplicated type definition.