### PR TITLE
chore(docs): remove next images config

### DIFF
--- a/apps/docs/next.config.mjs
+++ b/apps/docs/next.config.mjs
@@ -4,19 +4,6 @@ const withMDX = createMDX();
 
 /** @type {import('next').NextConfig} */
 const config = {
-  images: {
-    remotePatterns: [
-      {
-        hostname: "github.com",
-        protocol: "https",
-      },
-      {
-        hostname: "placehold.co",
-        protocol: "https",
-      },
-    ],
-  },
-
   redirects() {
     return [
       {


### PR DESCRIPTION
Removed remotePatterns configuration for images since it doesn't seem like the `next/image` component is used at all.