### PR TITLE
feat(audio-player): add playback speed control component

### DIFF
--- a/apps/docs/content/components/(voice)/audio-player.mdx
+++ b/apps/docs/content/components/(voice)/audio-player.mdx
@@ -18,6 +18,7 @@ The `AudioPlayer` component provides a flexible and customizable audio playback 
 - Fully composable architecture with granular control components
 - ButtonGroup integration for cohesive control layout
 - Individual control components (play, seek, volume, etc.)
+- Playback speed control with configurable rates
 - Flexible layout with customizable control bars
 - CSS custom properties for deep theming
 - Shadcn/ui Button component styling
@@ -146,6 +147,25 @@ Seek forward button wrapped in a shadcn Button component.
       description:
         "Any other props are spread to the MediaSeekForwardButton component.",
       type: "React.ComponentProps<typeof MediaSeekForwardButton>",
+    },
+  }}
+/>
+
+### `<AudioPlayerPlaybackRateButton />`
+
+Playback speed button, wrapped in a shadcn Button component.
+
+<TypeTable
+  type={{
+    rates: {
+      description: "Playback rates to cycle through.",
+      type: "ArrayLike<number>",
+      default: "[0.5, 1, 1.2, 1.5, 1.7, 2]",
+    },
+    "...props": {
+      description:
+        "Any other props are spread to the MediaPlaybackRateButton component.",
+      type: 'Omit<React.ComponentProps<typeof MediaPlaybackRateButton>, "rates">',
     },
   }}
 />

--- a/packages/elements/__tests__/audio-player.test.tsx
+++ b/packages/elements/__tests__/audio-player.test.tsx
@@ -7,6 +7,7 @@ import {
   AudioPlayerElement,
   AudioPlayerMuteButton,
   AudioPlayerPlayButton,
+  AudioPlayerPlaybackRateButton,
   AudioPlayerSeekBackwardButton,
   AudioPlayerSeekForwardButton,
   AudioPlayerTimeDisplay,
@@ -317,6 +318,60 @@ describe("audioPlayerMuteButton", () => {
   });
 });
 
+describe("audioPlayerPlaybackRateButton", () => {
+  it("renders playback rate button", () => {
+    const { container } = render(<AudioPlayerPlaybackRateButton />);
+    const button = container.querySelector(
+      '[data-slot="audio-player-playback-rate-button"]'
+    );
+    expect(button).toBeInTheDocument();
+  });
+
+  it("uses default playback rates", () => {
+    const { container } = render(<AudioPlayerPlaybackRateButton />);
+    const button = container.querySelector(
+      '[data-slot="audio-player-playback-rate-button"]'
+    );
+    expect(button).toHaveAttribute("rates", "0.5 1 1.2 1.5 1.7 2");
+  });
+
+  it("accepts custom playback rates", () => {
+    const { container } = render(
+      <AudioPlayerPlaybackRateButton rates={[0.75, 1, 1.25]} />
+    );
+    const button = container.querySelector(
+      '[data-slot="audio-player-playback-rate-button"]'
+    );
+    expect(button).toHaveAttribute("rates", "0.75 1 1.25");
+  });
+
+  it("applies custom className", () => {
+    const { container } = render(
+      <AudioPlayerPlaybackRateButton className="custom-rate" />
+    );
+    const button = container.querySelector(
+      '[data-slot="audio-player-playback-rate-button"]'
+    );
+    expect(button).toHaveClass("custom-rate");
+  });
+
+  it("uses a wider text-friendly button size", () => {
+    const { container } = render(<AudioPlayerPlaybackRateButton />);
+    const button = container.querySelector(
+      '[data-slot="audio-player-playback-rate-button"]'
+    );
+    expect(button).toHaveClass("w-14");
+  });
+
+  it("prevents selecting playback rate text", () => {
+    const { container } = render(<AudioPlayerPlaybackRateButton />);
+    const button = container.querySelector(
+      '[data-slot="audio-player-playback-rate-button"]'
+    );
+    expect(button).toHaveClass("select-none");
+  });
+});
+
 describe("audioPlayerVolumeRange", () => {
   it("renders volume range slider", () => {
     const { container } = render(<AudioPlayerVolumeRange />);
@@ -348,6 +403,7 @@ const renderCompleteAudioPlayer = () =>
         <AudioPlayerTimeDisplay />
         <AudioPlayerTimeRange />
         <AudioPlayerDurationDisplay />
+        <AudioPlayerPlaybackRateButton />
         <AudioPlayerMuteButton />
         <AudioPlayerVolumeRange />
       </AudioPlayerControlBar>
@@ -405,6 +461,13 @@ describe("integration tests", () => {
     ).toBeInTheDocument();
     expect(
       container.querySelector('[data-slot="audio-player-volume-range"]')
+    ).toBeInTheDocument();
+  });
+
+  it("renders playback rate button", () => {
+    const { container } = renderCompleteAudioPlayer();
+    expect(
+      container.querySelector('[data-slot="audio-player-playback-rate-button"]')
     ).toBeInTheDocument();
   });
 

--- a/packages/elements/src/audio-player.tsx
+++ b/packages/elements/src/audio-player.tsx
@@ -13,6 +13,7 @@ import {
   MediaDurationDisplay,
   MediaMuteButton,
   MediaPlayButton,
+  MediaPlaybackRateButton,
   MediaSeekBackwardButton,
   MediaSeekForwardButton,
   MediaTimeDisplay,
@@ -196,6 +197,30 @@ export const AudioPlayerDurationDisplay = ({
       {...props}
     />
   </ButtonGroupText>
+);
+
+export type AudioPlayerPlaybackRateButtonProps = Omit<
+  ComponentProps<typeof MediaPlaybackRateButton>,
+  "rates"
+> & {
+  rates?: ArrayLike<number>;
+};
+
+const DEFAULT_PLAYBACK_RATES = [0.5, 1, 1.2, 1.5, 1.7, 2];
+
+export const AudioPlayerPlaybackRateButton = ({
+  className,
+  rates = DEFAULT_PLAYBACK_RATES,
+  ...props
+}: AudioPlayerPlaybackRateButtonProps) => (
+  <Button asChild size="sm" variant="outline">
+    <MediaPlaybackRateButton
+      className={cn("w-14 select-none bg-transparent px-2 tabular-nums", className)}
+      data-slot="audio-player-playback-rate-button"
+      rates={rates}
+      {...props}
+    />
+  </Button>
 );
 
 export type AudioPlayerMuteButtonProps = ComponentProps<typeof MediaMuteButton>;

--- a/packages/examples/src/audio-player-remote.tsx
+++ b/packages/examples/src/audio-player-remote.tsx
@@ -7,6 +7,7 @@ import {
   AudioPlayerElement,
   AudioPlayerMuteButton,
   AudioPlayerPlayButton,
+  AudioPlayerPlaybackRateButton,
   AudioPlayerSeekBackwardButton,
   AudioPlayerSeekForwardButton,
   AudioPlayerTimeDisplay,
@@ -25,6 +26,7 @@ const Example = () => (
         <AudioPlayerTimeDisplay />
         <AudioPlayerTimeRange />
         <AudioPlayerDurationDisplay />
+        <AudioPlayerPlaybackRateButton />
         <AudioPlayerMuteButton />
         <AudioPlayerVolumeRange />
       </AudioPlayerControlBar>

--- a/packages/examples/src/audio-player.tsx
+++ b/packages/examples/src/audio-player.tsx
@@ -7,6 +7,7 @@ import {
   AudioPlayerElement,
   AudioPlayerMuteButton,
   AudioPlayerPlayButton,
+  AudioPlayerPlaybackRateButton,
   AudioPlayerSeekBackwardButton,
   AudioPlayerSeekForwardButton,
   AudioPlayerTimeDisplay,
@@ -57,6 +58,7 @@ const Example = () => {
           <AudioPlayerTimeDisplay />
           <AudioPlayerTimeRange />
           <AudioPlayerDurationDisplay />
+          <AudioPlayerPlaybackRateButton />
           <AudioPlayerMuteButton />
           <AudioPlayerVolumeRange />
         </AudioPlayerControlBar>

--- a/skills/ai-elements/references/audio-player.md
+++ b/skills/ai-elements/references/audio-player.md
@@ -18,6 +18,7 @@ npx ai-elements@latest add audio-player
 - Fully composable architecture with granular control components
 - ButtonGroup integration for cohesive control layout
 - Individual control components (play, seek, volume, etc.)
+- Playback speed control with configurable rates
 - Flexible layout with customizable control bars
 - CSS custom properties for deep theming
 - Shadcn/ui Button component styling
@@ -92,6 +93,15 @@ Seek forward button wrapped in a shadcn Button component.
 |------|------|---------|-------------|
 | `seekOffset` | `number` | `10` | The number of seconds to seek forward. |
 | `...props` | `React.ComponentProps<typeof MediaSeekForwardButton>` | - | Any other props are spread to the MediaSeekForwardButton component. |
+
+### `<AudioPlayerPlaybackRateButton />`
+
+Playback speed button, wrapped in a shadcn Button component.
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `rates` | `ArrayLike<number>` | `[0.5, 1, 1.2, 1.5, 1.7, 2]` | Playback rates to cycle through. |
+| `...props` | `Omit<React.ComponentProps<typeof MediaPlaybackRateButton>, "rates">` | - | Any other props are spread to the MediaPlaybackRateButton component. |
 
 ### `<AudioPlayerTimeDisplay />`
 

--- a/skills/ai-elements/scripts/audio-player-remote.tsx
+++ b/skills/ai-elements/scripts/audio-player-remote.tsx
@@ -7,6 +7,7 @@ import {
   AudioPlayerElement,
   AudioPlayerMuteButton,
   AudioPlayerPlayButton,
+  AudioPlayerPlaybackRateButton,
   AudioPlayerSeekBackwardButton,
   AudioPlayerSeekForwardButton,
   AudioPlayerTimeDisplay,
@@ -25,6 +26,7 @@ const Example = () => (
         <AudioPlayerTimeDisplay />
         <AudioPlayerTimeRange />
         <AudioPlayerDurationDisplay />
+        <AudioPlayerPlaybackRateButton />
         <AudioPlayerMuteButton />
         <AudioPlayerVolumeRange />
       </AudioPlayerControlBar>

--- a/skills/ai-elements/scripts/audio-player.tsx
+++ b/skills/ai-elements/scripts/audio-player.tsx
@@ -7,6 +7,7 @@ import {
   AudioPlayerElement,
   AudioPlayerMuteButton,
   AudioPlayerPlayButton,
+  AudioPlayerPlaybackRateButton,
   AudioPlayerSeekBackwardButton,
   AudioPlayerSeekForwardButton,
   AudioPlayerTimeDisplay,
@@ -57,6 +58,7 @@ const Example = () => {
           <AudioPlayerTimeDisplay />
           <AudioPlayerTimeRange />
           <AudioPlayerDurationDisplay />
+          <AudioPlayerPlaybackRateButton />
           <AudioPlayerMuteButton />
           <AudioPlayerVolumeRange />
         </AudioPlayerControlBar>


### PR DESCRIPTION
Introduced the `<AudioPlayerPlaybackRateButton />` component to allow users to control playback speed with configurable rates. Updated documentation and tests to reflect this new feature.