### PR TITLE
fix: respect components.json alias for install path

### DIFF
--- a/apps/docs/app/api/registry/[component]/route.ts
+++ b/apps/docs/app/api/registry/[component]/route.ts
@@ -180,7 +180,7 @@ const componentItems: RegistryItem[] = tsxFiles.map((componentFile) => {
     files: [
       {
         path: `registry/default/ai-elements/${componentFile.name}`,
-        target: `components/ai-elements/${componentFile.name}.tsx`,
+        target: `@components/ai-elements/${componentFile.name}.tsx`,
         type: "registry:component",
       },
     ],
@@ -203,7 +203,7 @@ const exampleItems: RegistryItem[] = exampleTsxFiles.map((exampleFile) => {
     files: [
       {
         path: `registry/default/examples/${exampleFile.name}`,
-        target: `components/ai-elements/examples/${exampleFile.name}.tsx`,
+        target: `@components/ai-elements/examples/${exampleFile.name}.tsx`,
         type: "registry:block",
       },
     ],
@@ -270,7 +270,7 @@ export const GET = async (request: NextRequest, { params }: RequestProps) => {
         allFiles.push({
           content: file.content,
           path: file.path,
-          target: `components/ai-elements/${componentFile.name}`,
+          target: `@components/ai-elements/${componentFile.name}`,
           type: file.type as RegistryItem["type"],
         });
 
@@ -463,7 +463,7 @@ export const GET = async (request: NextRequest, { params }: RequestProps) => {
       {
         content: file.content,
         path: file.path,
-        target: `components/ai-elements/${item.name}.tsx`,
+        target: `@components/ai-elements/${item.name}.tsx`,
         type: file.type as Exclude<
           RegistryItem["type"],
           "registry:base" | "registry:font"


### PR DESCRIPTION
## Problem

Installing ai-elements ignores the `components` alias in `components.json`, always writing files to `<project-root>/components/ai-elements/` regardless of how the project is configured.

Re-addresses #44, which was closed after PR #46 removed the `target` field, but commit 1c23c11 ("Add targets") reintroduced it shortly after, bringing the bug back.

## Root cause

shadcn's `resolveAliasTarget` only activates when a `target` starts with `@aliasKey/`. A plain `components/ai-elements/...` target bypasses alias resolution entirely and is treated as a literal path relative to the project root.

## Fix

Prefix all `target` values with `@components/` so shadcn resolves the destination through the `components` alias in `components.json`:

- Default config (`"components": "@/components"`) -> `components/ai-elements/` ✓
- Custom config (`"components": "@/lib/components"`) -> `lib/components/ai-elements/` ✓
- No `components.json` -> shadcn runs init first, then the default alias applies ✓

## Why not just remove `target`?

PR #46 tried this. The problem: without `target`, shadcn calls `resolveNestedFilePath(path, targetDir)` which looks for the last segment of the resolved components dir (e.g. `"components"`) inside the file's `path` string (`registry/default/ai-elements/conversation.tsx`). No match is found, so it falls back to just the filename, and files would land at `lib/components/conversation.tsx` instead of `lib/components/ai-elements/conversation.tsx`.
