### PR TITLE
fix: resolve type error in SchemaDisplayPath dangerouslySetInnerHTML

### DIFF
--- a/packages/elements/src/schema-display.tsx
+++ b/packages/elements/src/schema-display.tsx
@@ -103,11 +103,19 @@ export const SchemaDisplayPath = ({
     '<span class="text-blue-600 dark:text-blue-400">{$1}</span>'
   );
 
+  if (children) {
+    return (
+      <span className={cn("font-mono text-sm", className)} {...props}>
+        {children}
+      </span>
+    );
+  }
+
   return (
     <span
       className={cn("font-mono text-sm", className)}
       // oxlint-disable-next-line eslint-plugin-react(no-danger)
-      dangerouslySetInnerHTML={{ __html: children ?? highlightedPath }}
+      dangerouslySetInnerHTML={{ __html: highlightedPath }}
       {...props}
     />
   );


### PR DESCRIPTION
## What

`SchemaDisplayPath` passed `children` (typed as `ReactNode`) directly to
`dangerouslySetInnerHTML.__html`, which requires `string | TrustedHTML`. This
caused a build-time TypeScript error under `strict: true`, reproducible on a
**fresh, unmodified `create-next-app` project** on its very first `next build`.

Fixes #441

## Why

`children ?? highlightedPath` can resolve to a `number`, `boolean`,
`ReactElement`, etc., none of which are assignable to `__html`. Conceptually,
injecting `children` as raw HTML is also fragile — `children` should be treated
as a normal React node. This also aligns with the project guideline to avoid
`dangerouslySetInnerHTML` unless necessary.

## How

- When `children` is provided, render it normally inside the `<span>`.
- Only the default `highlightedPath` (a `string`) is injected via
  `dangerouslySetInnerHTML`.

```tsx
if (children) {
  return (
    <span className={cn("font-mono text-sm", className)} {...props}>
      {children}
    </span>
  );
}

return (
  <span
    className={cn("font-mono text-sm", className)}
    // oxlint-disable-next-line eslint-plugin-react(no-danger)
    dangerouslySetInnerHTML={{ __html: highlightedPath }}
    {...props}
  />
);
```

**Behavior impact**

All current usages in this repo render <SchemaDisplayPath /> without
children, so there is no behavior change. The only difference is for callers
that previously passed an HTML string as children expecting it to be parsed
as HTML — it is now rendered as text, which is the safer and more idiomatic
React behavior.

**Steps to reproduce (before this fix)**

1. npx create-next-app@latest my-app --yes
2. cd my-app && npx ai-elements@latest
3. npm run build → fails type-check at schema-display.tsx:110

**Testing**

- pnpm check — formatting passes.
- tsc --noEmit — schema-display.tsx type-checks cleanly (the remaining
errors in the package are pre-existing and unrelated to this change).