### PR TITLE
fix(skills): replace fake tokens with obvious placeholders

### DIFF
--- a/packages/examples/src/environment-variables.tsx
+++ b/packages/examples/src/environment-variables.tsx
@@ -20,7 +20,7 @@ const variables = [
     required: true,
     value: "postgresql://localhost:5432/mydb",
   },
-  { name: "API_KEY", required: true, value: "sk-1234567890abcdef" },
+  { name: "API_KEY", required: true, value: "<YOUR_API_KEY_HERE>" },
   { name: "NODE_ENV", required: false, value: "production" },
   { name: "PORT", required: false, value: "3000" },
 ];

--- a/packages/examples/src/tool-output-error.tsx
+++ b/packages/examples/src/tool-output-error.tsx
@@ -14,7 +14,7 @@ const toolCall: ToolUIPart = {
     "Connection timeout: The request took longer than 5000ms to complete. Please check your network connection and try again.",
   input: {
     headers: {
-      Authorization: "Bearer token123",
+      Authorization: "Bearer <YOUR_TOKEN_HERE>",
       "Content-Type": "application/json",
     },
     method: "GET",

--- a/skills/ai-elements/scripts/environment-variables.tsx
+++ b/skills/ai-elements/scripts/environment-variables.tsx
@@ -20,7 +20,7 @@ const variables = [
     required: true,
     value: "postgresql://localhost:5432/mydb",
   },
-  { name: "API_KEY", required: true, value: "sk-1234567890abcdef" },
+  { name: "API_KEY", required: true, value: "<YOUR_API_KEY_HERE>" },
   { name: "NODE_ENV", required: false, value: "production" },
   { name: "PORT", required: false, value: "3000" },
 ];

--- a/skills/ai-elements/scripts/tool-output-error.tsx
+++ b/skills/ai-elements/scripts/tool-output-error.tsx
@@ -14,7 +14,7 @@ const toolCall: ToolUIPart = {
     "Connection timeout: The request took longer than 5000ms to complete. Please check your network connection and try again.",
   input: {
     headers: {
-      Authorization: "Bearer token123",
+      Authorization: "Bearer <YOUR_TOKEN_HERE>",
       "Content-Type": "application/json",
     },
     method: "GET",


### PR DESCRIPTION
The fake tokens are hitting security scanning alerts, replacing them with obvious placeholders will prevent it while agents still know it's supposed to be a token
