### PR TITLE
feat: add prompt input mentions and slash commands

### DIFF
--- a/.changeset/prompt-input-suggestions.md
+++ b/.changeset/prompt-input-suggestions.md
@@ -1,0 +1,5 @@
+---
+"ai-elements": patch
+---
+
+Add contextual mention and slash-command suggestions to PromptInput.

--- a/apps/docs/content/components/(chatbot)/prompt-input.mdx
+++ b/apps/docs/content/components/(chatbot)/prompt-input.mdx
@@ -237,11 +237,68 @@ export async function POST(req: Request) {
 }
 ```
 
+## Mentions and slash commands
+
+Wrap the prompt in `PromptInputSuggestions` to open a keyboard-accessible suggestion list when the user types a configured trigger. The hook exposes the active trigger and query so you can filter local or remote results.
+
+Suggestions replace text in the existing textarea, so the prompt's plain-text submission contract remains unchanged.
+
+```tsx
+const files = [
+  "packages/elements/src/prompt-input.tsx",
+  "packages/elements/src/message.tsx",
+];
+const commands = ["search", "summarize", "explain"];
+const triggers = [{ trigger: "@" }, { trigger: "/", startOfLine: true }];
+
+const SuggestionMenu = () => {
+  const { match } = usePromptInputSuggestions();
+
+  if (!match) {
+    return null;
+  }
+
+  const items = match.trigger === "@" ? files : commands;
+  const filteredItems = items.filter((item) =>
+    item.toLowerCase().includes(match.query.toLowerCase())
+  );
+
+  return (
+    <PromptInputSuggestionContent>
+      {filteredItems.length > 0 ? (
+        filteredItems.map((item) => (
+          <PromptInputSuggestionItem key={item} value={item}>
+            {match.trigger}
+            {item}
+          </PromptInputSuggestionItem>
+        ))
+      ) : (
+        <PromptInputSuggestionEmpty>
+          No results found.
+        </PromptInputSuggestionEmpty>
+      )}
+    </PromptInputSuggestionContent>
+  );
+};
+
+<PromptInputSuggestions triggers={triggers}>
+  <PromptInput onSubmit={handleSubmit}>
+    <PromptInputBody>
+      <PromptInputTextarea placeholder="Type @ for files or / for commands" />
+    </PromptInputBody>
+  </PromptInput>
+  <SuggestionMenu />
+</PromptInputSuggestions>;
+```
+
+By default, selecting an item replaces the active query with its trigger and value followed by a space. Use `replaceWith` or `onSelect` on `PromptInputSuggestionItem` when you need custom insertion or selection behavior.
+
 ## Features
 
 - Auto-resizing textarea that adjusts height based on content
 - File attachment support with drag-and-drop
 - Built-in screenshot capture action
+- Contextual `@` mentions and `/` slash-command suggestions
 - Image preview for image attachments
 - Configurable file constraints (max files, max size, accepted types)
 - Automatic submit button icons based on status
@@ -326,6 +383,142 @@ Buttons can display tooltips with optional keyboard shortcut hints. Hover over t
       description:
         "Any other props are spread to the underlying Textarea component.",
       type: "React.ComponentProps<typeof Textarea>",
+    },
+  }}
+/>
+
+### `<PromptInputSuggestions />`
+
+Provides suggestion state and connects a descendant `PromptInputTextarea` to the suggestion content.
+
+<TypeTable
+  type={{
+    triggers: {
+      description: "Trigger configurations that activate suggestions.",
+      type: "readonly PromptInputSuggestionTrigger[]",
+      required: true,
+    },
+    onMatchChange: {
+      description: "Called when the active trigger, query, or range changes.",
+      type: "PromptInputSuggestionMatch change callback",
+    },
+    onOpenChange: {
+      description: "Called when the suggestion popover opens or closes.",
+      type: "(open: boolean) => void",
+    },
+    children: {
+      description: "The prompt input and suggestion content.",
+      type: "React.ReactNode",
+    },
+  }}
+/>
+
+#### `PromptInputSuggestionTrigger`
+
+<TypeTable
+  type={{
+    trigger: {
+      description:
+        "Text that activates suggestions, for example an at sign or slash.",
+      type: "string",
+      required: true,
+    },
+    allowSpaces: {
+      description: "Whether the active query may contain spaces.",
+      type: "boolean",
+      default: "false",
+    },
+    allowedPrefixes: {
+      description:
+        "Characters allowed immediately before the trigger. Use null to allow any prefix.",
+      type: "readonly string array or null",
+      default: "space, newline, or tab",
+    },
+    minQueryLength: {
+      description: "Minimum query length required before matching.",
+      type: "number",
+      default: "0",
+    },
+    maxQueryLength: {
+      description: "Maximum query length that remains active.",
+      type: "number",
+    },
+    startOfLine: {
+      description: "Whether the trigger must appear at the start of a line.",
+      type: "boolean",
+      default: "false",
+    },
+  }}
+/>
+
+### `<PromptInputSuggestionContent />`
+
+Portal-backed listbox positioned relative to the prompt textarea.
+
+<TypeTable
+  type={{
+    "aria-label": {
+      description: "Accessible label for the suggestion listbox.",
+      type: "string",
+      default: "Suggestions",
+    },
+    align: {
+      description: "Alignment relative to the textarea.",
+      type: "start, center, or end",
+      default: "start",
+    },
+    side: {
+      description: "Preferred side of the textarea.",
+      type: "top, right, bottom, or left",
+      default: "top",
+    },
+    sideOffset: {
+      description: "Distance from the textarea in pixels.",
+      type: "number",
+      default: "8",
+    },
+    "...props": {
+      description: "Any other props are spread to PopoverContent.",
+      type: "React.ComponentProps<typeof PopoverContent>",
+    },
+  }}
+/>
+
+### `<PromptInputSuggestionItem />`
+
+Keyboard- and pointer-selectable suggestion option. The default replacement is `{trigger}{value} `.
+
+<TypeTable
+  type={{
+    value: {
+      description: "Value used for navigation state and default insertion.",
+      type: "string",
+      required: true,
+    },
+    replaceWith: {
+      description:
+        "Custom replacement text or function. Set false to handle insertion yourself.",
+      type: "string, false, or replacement function",
+    },
+    onSelect: {
+      description:
+        "Called with the selected value, match, and replacement helpers.",
+      type: "(details: PromptInputSuggestionSelectDetails) => void",
+    },
+    "...props": {
+      description: "Any other props are spread to the underlying button.",
+      type: "React button props except onSelect and value",
+    },
+  }}
+/>
+
+### `<PromptInputSuggestionEmpty />`
+
+<TypeTable
+  type={{
+    "...props": {
+      description: "Any other props are spread to the empty-state div.",
+      type: "React.HTMLAttributes<HTMLDivElement>",
     },
   }}
 />
@@ -776,6 +969,23 @@ Optional global provider that lifts PromptInput state outside of PromptInput. Wh
 />
 
 ## Hooks
+
+### `usePromptInputSuggestions`
+
+Access the active suggestion state within `PromptInputSuggestions`.
+
+```tsx
+const { activeValue, close, match, open, replace } =
+  usePromptInputSuggestions();
+
+match?.trigger; // Active trigger
+match?.query; // Text after the trigger
+match?.range; // Trigger-to-caret replacement range
+activeValue; // Value of the keyboard-highlighted item
+open; // Whether the suggestion list is open
+replace("@replacement "); // Replace the active range and restore focus
+close(); // Dismiss the current match
+```
 
 ### `usePromptInputAttachments`
 

--- a/packages/elements/__tests__/prompt-input.test.tsx
+++ b/packages/elements/__tests__/prompt-input.test.tsx
@@ -1,5 +1,5 @@
 // oxlint-disable eslint-plugin-jest(max-expects), eslint-plugin-react-perf(jsx-no-new-function-as-prop)
-import { act, render, screen } from "@testing-library/react";
+import { act, fireEvent, render, screen } from "@testing-library/react";
 import { userEvent } from "@testing-library/user-event";
 import React from "react";
 
@@ -11,6 +11,7 @@ import {
   AttachmentRemove,
   Attachments,
 } from "../src/attachments";
+import type { PromptInputSuggestionSelectDetails } from "../src/prompt-input";
 import {
   PromptInput,
   PromptInputActionAddAttachments,
@@ -21,21 +22,129 @@ import {
   PromptInputActionMenuTrigger,
   PromptInputBody,
   PromptInputButton,
+  PromptInputProvider,
   PromptInputSelect,
   PromptInputSelectContent,
   PromptInputSelectItem,
   PromptInputSelectTrigger,
   PromptInputSelectValue,
   PromptInputSubmit,
+  PromptInputSuggestionContent,
+  PromptInputSuggestionItem,
+  PromptInputSuggestions,
   PromptInputTextarea,
   PromptInputTools,
   usePromptInputAttachments,
+  usePromptInputController,
   usePromptInputReferencedSources,
+  usePromptInputSuggestions,
 } from "../src/prompt-input";
 
 const DATA_PREFIX_REGEX = /^data:/;
 const BLOB_PREFIX_REGEX = /^blob:/;
 const SUBMIT_REGEX = /submit/i;
+const PROMPT_INPUT_SUGGESTION_TRIGGERS = [
+  { trigger: "@" },
+  { trigger: "/" },
+] as const;
+
+const MENTION_SUGGESTIONS = ["Ada", "Alan"] as const;
+const COMMAND_SUGGESTIONS = ["clear", "summarize"] as const;
+
+const preventArrowDown = (
+  event: React.KeyboardEvent<HTMLTextAreaElement>
+): void => {
+  if (event.key === "ArrowDown") {
+    event.preventDefault();
+  }
+};
+
+interface FilteredSuggestionMenuProps {
+  clearIsActionOnly?: boolean;
+  onClear?: (details: PromptInputSuggestionSelectDetails) => void;
+}
+
+const FilteredSuggestionMenu = ({
+  clearIsActionOnly = false,
+  onClear,
+}: FilteredSuggestionMenuProps) => {
+  const { match } = usePromptInputSuggestions();
+  const suggestions =
+    match?.trigger === "@" ? MENTION_SUGGESTIONS : COMMAND_SUGGESTIONS;
+  const query = match?.query.toLowerCase() ?? "";
+  const filteredSuggestions = suggestions.filter((suggestion) =>
+    suggestion.toLowerCase().includes(query)
+  );
+
+  return (
+    <PromptInputSuggestionContent aria-label="Prompt suggestions">
+      <output data-testid="suggestion-query">
+        {match ? `${match.trigger}:${match.query}` : ""}
+      </output>
+      {filteredSuggestions.map((suggestion) => (
+        <PromptInputSuggestionItem
+          key={suggestion}
+          onSelect={suggestion === "clear" ? onClear : undefined}
+          replaceWith={
+            suggestion === "clear" && clearIsActionOnly ? false : undefined
+          }
+          value={suggestion}
+        >
+          {suggestion}
+        </PromptInputSuggestionItem>
+      ))}
+    </PromptInputSuggestionContent>
+  );
+};
+
+const MidStringSuggestionMenu = () => (
+  <PromptInputSuggestionContent aria-label="Mention suggestions">
+    <PromptInputSuggestionItem replaceWith="@Ada" value="Ada">
+      Ada
+    </PromptInputSuggestionItem>
+  </PromptInputSuggestionContent>
+);
+
+const PromptInputProviderValue = () => {
+  const controller = usePromptInputController();
+  return (
+    <output data-testid="provider-value">{controller.textInput.value}</output>
+  );
+};
+
+const PromptInputSuggestionState = () => {
+  const { activeValue, match, open } = usePromptInputSuggestions();
+  const openState = open ? "open" : "closed";
+  return (
+    <output data-testid="suggestion-state">
+      {`${openState}:${match?.query ?? "none"}:${activeValue ?? "none"}`}
+    </output>
+  );
+};
+
+const ConditionalSuggestionTextarea = ({
+  onSubmit,
+}: {
+  onSubmit: () => void;
+}) => {
+  const [showTextarea, setShowTextarea] = React.useState(true);
+
+  return (
+    <>
+      <button onClick={() => setShowTextarea(false)} type="button">
+        Hide textarea
+      </button>
+      <PromptInput onSubmit={onSubmit}>
+        <PromptInputBody>
+          <PromptInputSuggestions triggers={PROMPT_INPUT_SUGGESTION_TRIGGERS}>
+            {showTextarea ? <PromptInputTextarea /> : null}
+            <PromptInputSuggestionState />
+          </PromptInputSuggestions>
+        </PromptInputBody>
+      </PromptInput>
+    </>
+  );
+};
 
 // Backwards-compatibility aliases for tests (these components were moved to attachment.tsx)
 const PromptInputAttachment = ({
@@ -756,6 +865,564 @@ describe("promptInputTextarea", () => {
     expect(
       screen.getByPlaceholderText("Custom placeholder")
     ).toBeInTheDocument();
+  });
+});
+
+describe("promptInputSuggestions", () => {
+  it("matches and filters @ mentions and / commands from the active query", async () => {
+    setupPromptInputTests();
+    const onSubmit = vi.fn();
+    const user = userEvent.setup();
+
+    render(
+      <PromptInput onSubmit={onSubmit}>
+        <PromptInputBody>
+          <PromptInputSuggestions triggers={PROMPT_INPUT_SUGGESTION_TRIGGERS}>
+            <PromptInputTextarea />
+            <FilteredSuggestionMenu />
+          </PromptInputSuggestions>
+        </PromptInputBody>
+      </PromptInput>
+    );
+
+    const textarea = screen.getByPlaceholderText(
+      "What would you like to know?"
+    );
+    await user.type(textarea, "Ask @ad");
+
+    const mentionListbox = await screen.findByRole("listbox");
+    expect(mentionListbox).toBeInTheDocument();
+    expect(screen.getByTestId("suggestion-query")).toHaveTextContent("@:ad");
+    expect(screen.getByRole("option", { name: "Ada" })).toBeInTheDocument();
+    expect(
+      screen.queryByRole("option", { name: "Alan" })
+    ).not.toBeInTheDocument();
+
+    await user.clear(textarea);
+    await user.type(textarea, "Please /sum");
+
+    const commandListbox = await screen.findByRole("listbox");
+    expect(commandListbox).toBeInTheDocument();
+    expect(screen.getByTestId("suggestion-query")).toHaveTextContent("/:sum");
+    expect(
+      screen.getByRole("option", { name: "summarize" })
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("option", { name: "clear" })
+    ).not.toBeInTheDocument();
+  });
+
+  it("does not activate mentions inside email addresses or commands inside URLs", async () => {
+    setupPromptInputTests();
+    const onSubmit = vi.fn();
+    const user = userEvent.setup();
+
+    render(
+      <PromptInput onSubmit={onSubmit}>
+        <PromptInputBody>
+          <PromptInputSuggestions triggers={PROMPT_INPUT_SUGGESTION_TRIGGERS}>
+            <PromptInputTextarea />
+            <FilteredSuggestionMenu />
+          </PromptInputSuggestions>
+        </PromptInputBody>
+      </PromptInput>
+    );
+
+    const textarea = screen.getByPlaceholderText(
+      "What would you like to know?"
+    );
+    await user.type(textarea, "user@example.com");
+
+    expect(textarea).toHaveAttribute("aria-expanded", "false");
+    expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+
+    await user.clear(textarea);
+    await user.type(textarea, "https://example.com/docs");
+
+    expect(textarea).toHaveAttribute("aria-expanded", "false");
+    expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+  });
+
+  it("navigates options with active-descendant and selects before submitting", async () => {
+    setupPromptInputTests();
+    const onSubmit = vi.fn();
+    const user = userEvent.setup();
+
+    render(
+      <PromptInput onSubmit={onSubmit}>
+        <PromptInputBody>
+          <PromptInputSuggestions triggers={PROMPT_INPUT_SUGGESTION_TRIGGERS}>
+            <PromptInputTextarea />
+            <FilteredSuggestionMenu />
+          </PromptInputSuggestions>
+          <PromptInputSubmit />
+        </PromptInputBody>
+      </PromptInput>
+    );
+
+    const textarea = screen.getByPlaceholderText(
+      "What would you like to know?"
+    ) as HTMLTextAreaElement;
+    await user.type(textarea, "@");
+
+    const ada = await screen.findByRole("option", { name: "Ada" });
+    const alan = screen.getByRole("option", { name: "Alan" });
+    await vi.waitFor(() => {
+      expect(textarea).toHaveAttribute("aria-activedescendant", ada.id);
+    });
+
+    await user.keyboard("{ArrowUp}");
+
+    expect(textarea).toHaveAttribute("aria-activedescendant", alan.id);
+    expect(alan).toHaveAttribute("aria-selected", "true");
+
+    await user.keyboard("{Enter}");
+
+    await vi.waitFor(() => {
+      expect(textarea).toHaveValue("@Alan ");
+    });
+    expect(onSubmit).not.toHaveBeenCalled();
+    expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+  });
+
+  it("keeps an escaped match dismissed until a new trigger context starts", async () => {
+    setupPromptInputTests();
+    const onSubmit = vi.fn();
+    const user = userEvent.setup();
+
+    render(
+      <PromptInput onSubmit={onSubmit}>
+        <PromptInputBody>
+          <PromptInputSuggestions triggers={PROMPT_INPUT_SUGGESTION_TRIGGERS}>
+            <PromptInputTextarea />
+            <FilteredSuggestionMenu />
+          </PromptInputSuggestions>
+        </PromptInputBody>
+      </PromptInput>
+    );
+
+    const textarea = screen.getByPlaceholderText(
+      "What would you like to know?"
+    );
+    await user.type(textarea, "@a");
+    const initialListbox = await screen.findByRole("listbox");
+    expect(initialListbox).toBeInTheDocument();
+
+    await user.keyboard("{Escape}");
+
+    expect(textarea).toHaveAttribute("aria-expanded", "false");
+    expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+
+    await user.type(textarea, "d");
+    expect(textarea).toHaveAttribute("aria-expanded", "false");
+
+    await user.type(textarea, " @");
+    const nextListbox = await screen.findByRole("listbox");
+    expect(nextListbox).toBeInTheDocument();
+    expect(textarea).toHaveAttribute("aria-expanded", "true");
+  });
+
+  it("preserves the suffix and textarea focus when a mid-string item is clicked", async () => {
+    setupPromptInputTests();
+    const onSubmit = vi.fn();
+    const user = userEvent.setup();
+
+    render(
+      <PromptInput onSubmit={onSubmit}>
+        <PromptInputBody>
+          <PromptInputSuggestions triggers={PROMPT_INPUT_SUGGESTION_TRIGGERS}>
+            <PromptInputTextarea defaultValue="Ask @ad about this" />
+            <MidStringSuggestionMenu />
+          </PromptInputSuggestions>
+        </PromptInputBody>
+      </PromptInput>
+    );
+
+    const textarea = screen.getByPlaceholderText(
+      "What would you like to know?"
+    ) as HTMLTextAreaElement;
+    textarea.focus();
+    textarea.setSelectionRange(7, 7);
+    fireEvent.select(textarea);
+
+    const option = await screen.findByRole("option", { name: "Ada" });
+    await user.click(option);
+
+    expect(textarea).toHaveValue("Ask @Ada about this");
+    expect(document.activeElement).toBe(textarea);
+  });
+
+  it("runs action-only items without replacing the active query", async () => {
+    setupPromptInputTests();
+    const onSubmit = vi.fn();
+    const onClear = vi.fn();
+    const user = userEvent.setup();
+
+    render(
+      <PromptInput onSubmit={onSubmit}>
+        <PromptInputBody>
+          <PromptInputSuggestions triggers={PROMPT_INPUT_SUGGESTION_TRIGGERS}>
+            <PromptInputTextarea />
+            <FilteredSuggestionMenu clearIsActionOnly onClear={onClear} />
+          </PromptInputSuggestions>
+        </PromptInputBody>
+      </PromptInput>
+    );
+
+    const textarea = screen.getByPlaceholderText(
+      "What would you like to know?"
+    ) as HTMLTextAreaElement;
+    await user.type(textarea, "/cl");
+    await user.click(await screen.findByRole("option", { name: "clear" }));
+
+    expect(textarea).toHaveValue("/cl");
+    expect(onClear).toHaveBeenCalledWith(
+      expect.objectContaining({
+        match: expect.objectContaining({ query: "cl", trigger: "/" }),
+        value: "clear",
+      })
+    );
+    expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+  });
+
+  it("updates PromptInputProvider state when a suggestion replaces text", async () => {
+    setupPromptInputTests();
+    const onSubmit = vi.fn();
+    const user = userEvent.setup();
+
+    render(
+      <PromptInputProvider>
+        <PromptInputProviderValue />
+        <PromptInput onSubmit={onSubmit}>
+          <PromptInputBody>
+            <PromptInputSuggestions triggers={PROMPT_INPUT_SUGGESTION_TRIGGERS}>
+              <PromptInputTextarea />
+              <FilteredSuggestionMenu />
+            </PromptInputSuggestions>
+          </PromptInputBody>
+        </PromptInput>
+      </PromptInputProvider>
+    );
+
+    const textarea = screen.getByPlaceholderText(
+      "What would you like to know?"
+    ) as HTMLTextAreaElement;
+    await user.type(textarea, "@ad");
+    await user.keyboard("{Enter}");
+
+    await vi.waitFor(() => {
+      expect(textarea).toHaveValue("@Ada ");
+      expect(screen.getByTestId("provider-value").textContent).toBe("@Ada ");
+    });
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it("waits for IME composition to end before opening suggestions", async () => {
+    setupPromptInputTests();
+    const onSubmit = vi.fn();
+    const onChange = vi.fn();
+    const onCompositionEnd = vi.fn();
+    const onCompositionStart = vi.fn();
+
+    render(
+      <PromptInput onSubmit={onSubmit}>
+        <PromptInputBody>
+          <PromptInputSuggestions triggers={PROMPT_INPUT_SUGGESTION_TRIGGERS}>
+            <PromptInputTextarea
+              onChange={onChange}
+              onCompositionEnd={onCompositionEnd}
+              onCompositionStart={onCompositionStart}
+            />
+            <FilteredSuggestionMenu />
+          </PromptInputSuggestions>
+        </PromptInputBody>
+      </PromptInput>
+    );
+
+    const textarea = screen.getByPlaceholderText(
+      "What would you like to know?"
+    ) as HTMLTextAreaElement;
+    textarea.focus();
+    fireEvent.compositionStart(textarea);
+    fireEvent.input(textarea, { target: { value: "@a" } });
+
+    expect(onCompositionStart).toHaveBeenCalledOnce();
+    expect(onChange).toHaveBeenCalled();
+    expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+
+    fireEvent.compositionEnd(textarea);
+
+    expect(onCompositionEnd).toHaveBeenCalledOnce();
+    const listbox = await screen.findByRole("listbox");
+    expect(listbox).toBeInTheDocument();
+  });
+
+  it("runs external key handlers before internal suggestion navigation", async () => {
+    setupPromptInputTests();
+    const onSubmit = vi.fn();
+    const onSelect = vi.fn();
+    const onKeyDown = vi.fn(preventArrowDown);
+    const user = userEvent.setup();
+
+    render(
+      <PromptInput onSubmit={onSubmit}>
+        <PromptInputBody>
+          <PromptInputSuggestions triggers={PROMPT_INPUT_SUGGESTION_TRIGGERS}>
+            <PromptInputTextarea onKeyDown={onKeyDown} onSelect={onSelect} />
+            <FilteredSuggestionMenu />
+          </PromptInputSuggestions>
+        </PromptInputBody>
+      </PromptInput>
+    );
+
+    const textarea = screen.getByPlaceholderText(
+      "What would you like to know?"
+    );
+    await user.type(textarea, "@");
+    const ada = await screen.findByRole("option", { name: "Ada" });
+    await vi.waitFor(() => {
+      expect(textarea).toHaveAttribute("aria-activedescendant", ada.id);
+    });
+    onKeyDown.mockClear();
+
+    await user.keyboard("{ArrowDown}");
+
+    expect(onKeyDown).toHaveBeenCalledOnce();
+    expect(onSelect).toHaveBeenCalled();
+    expect(textarea).toHaveAttribute("aria-activedescendant", ada.id);
+  });
+
+  it("exposes the textarea as a combobox while suggestions are enabled", () => {
+    setupPromptInputTests();
+    const onSubmit = vi.fn();
+
+    render(
+      <PromptInput onSubmit={onSubmit}>
+        <PromptInputBody>
+          <PromptInputSuggestions triggers={PROMPT_INPUT_SUGGESTION_TRIGGERS}>
+            <PromptInputTextarea />
+            <FilteredSuggestionMenu />
+          </PromptInputSuggestions>
+        </PromptInputBody>
+      </PromptInput>
+    );
+
+    const textarea = screen.getByRole("combobox");
+    expect(textarea).toHaveAttribute("aria-autocomplete", "list");
+    expect(textarea).toHaveAttribute("data-slot", "input-group-control");
+  });
+
+  it("keeps the same match open when the caret moves inside the textarea", async () => {
+    setupPromptInputTests();
+    const onSubmit = vi.fn();
+    const user = userEvent.setup();
+
+    render(
+      <PromptInput onSubmit={onSubmit}>
+        <PromptInputBody>
+          <PromptInputSuggestions triggers={PROMPT_INPUT_SUGGESTION_TRIGGERS}>
+            <PromptInputTextarea />
+            <FilteredSuggestionMenu />
+          </PromptInputSuggestions>
+        </PromptInputBody>
+      </PromptInput>
+    );
+
+    const textarea = screen.getByPlaceholderText(
+      "What would you like to know?"
+    ) as HTMLTextAreaElement;
+    await user.type(textarea, "@a");
+    const listbox = await screen.findByRole("listbox");
+    expect(listbox).toBeInTheDocument();
+
+    await user.pointer({ keys: "[MouseLeft>]", target: textarea });
+    textarea.setSelectionRange(1, 1);
+    fireEvent.select(textarea);
+    await user.pointer({ keys: "[/MouseLeft]", target: textarea });
+
+    expect(textarea).toHaveAttribute("aria-expanded", "true");
+    expect(screen.getByRole("listbox")).toBeInTheDocument();
+    expect(screen.getByTestId("suggestion-query")).toHaveTextContent("@:");
+  });
+
+  it("keeps a consumer-provided option id in sync with active-descendant", async () => {
+    setupPromptInputTests();
+    const onSubmit = vi.fn();
+    const user = userEvent.setup();
+
+    render(
+      <PromptInput onSubmit={onSubmit}>
+        <PromptInputBody>
+          <PromptInputSuggestions triggers={PROMPT_INPUT_SUGGESTION_TRIGGERS}>
+            <PromptInputTextarea />
+            <PromptInputSuggestionContent aria-label="Mention suggestions">
+              <PromptInputSuggestionItem id="custom-option-id" value="Ada">
+                Ada
+              </PromptInputSuggestionItem>
+            </PromptInputSuggestionContent>
+          </PromptInputSuggestions>
+        </PromptInputBody>
+      </PromptInput>
+    );
+
+    const textarea = screen.getByPlaceholderText(
+      "What would you like to know?"
+    );
+    await user.type(textarea, "@");
+    const option = await screen.findByRole("option", { name: "Ada" });
+
+    await vi.waitFor(() => {
+      expect(textarea).toHaveAttribute("aria-activedescendant", option.id);
+    });
+    expect(option).toHaveAttribute("id", "custom-option-id");
+  });
+
+  it("scrolls the keyboard-selected option into view", async () => {
+    setupPromptInputTests();
+    const onSubmit = vi.fn();
+    const scrollIntoView = vi
+      .spyOn(Element.prototype, "scrollIntoView")
+      .mockImplementation(vi.fn());
+    const user = userEvent.setup();
+
+    render(
+      <PromptInput onSubmit={onSubmit}>
+        <PromptInputBody>
+          <PromptInputSuggestions triggers={PROMPT_INPUT_SUGGESTION_TRIGGERS}>
+            <PromptInputTextarea />
+            <FilteredSuggestionMenu />
+          </PromptInputSuggestions>
+        </PromptInputBody>
+      </PromptInput>
+    );
+
+    const textarea = screen.getByPlaceholderText(
+      "What would you like to know?"
+    );
+    await user.type(textarea, "@");
+    const alan = await screen.findByRole("option", { name: "Alan" });
+    scrollIntoView.mockClear();
+
+    await user.keyboard("{ArrowDown}");
+
+    expect(alan).toHaveAttribute("aria-selected", "true");
+    expect(scrollIntoView).toHaveBeenCalledWith({ block: "nearest" });
+  });
+
+  it("resets suggestions when a conditional textarea unmounts", async () => {
+    setupPromptInputTests();
+    const onSubmit = vi.fn();
+    const user = userEvent.setup();
+    render(<ConditionalSuggestionTextarea onSubmit={onSubmit} />);
+
+    const textarea = screen.getByRole("combobox");
+    await user.type(textarea, "@a");
+    expect(screen.getByTestId("suggestion-state")).toHaveTextContent(
+      "open:a:none"
+    );
+
+    await user.click(screen.getByRole("button", { name: "Hide textarea" }));
+
+    await vi.waitFor(() => {
+      expect(screen.getByTestId("suggestion-state")).toHaveTextContent(
+        "closed:none:none"
+      );
+    });
+  });
+
+  it("keeps a stable active item id while its value changes", async () => {
+    setupPromptInputTests();
+    const onSubmit = vi.fn();
+    const user = userEvent.setup();
+    const { rerender } = render(
+      <PromptInput onSubmit={onSubmit}>
+        <PromptInputBody>
+          <PromptInputSuggestions triggers={PROMPT_INPUT_SUGGESTION_TRIGGERS}>
+            <PromptInputTextarea />
+            <PromptInputSuggestionState />
+            <PromptInputSuggestionContent aria-label="Mention suggestions">
+              <PromptInputSuggestionItem id="stable-option" value="Ada">
+                Ada
+              </PromptInputSuggestionItem>
+            </PromptInputSuggestionContent>
+          </PromptInputSuggestions>
+        </PromptInputBody>
+      </PromptInput>
+    );
+
+    const textarea = screen.getByRole("combobox");
+    await user.type(textarea, "@");
+    const option = await screen.findByRole("option", { name: "Ada" });
+    await vi.waitFor(() => {
+      expect(textarea).toHaveAttribute("aria-activedescendant", option.id);
+      expect(screen.getByTestId("suggestion-state")).toHaveTextContent(
+        "open::Ada"
+      );
+    });
+
+    rerender(
+      <PromptInput onSubmit={onSubmit}>
+        <PromptInputBody>
+          <PromptInputSuggestions triggers={PROMPT_INPUT_SUGGESTION_TRIGGERS}>
+            <PromptInputTextarea />
+            <PromptInputSuggestionState />
+            <PromptInputSuggestionContent aria-label="Mention suggestions">
+              <PromptInputSuggestionItem id="stable-option" value="Grace">
+                Grace
+              </PromptInputSuggestionItem>
+            </PromptInputSuggestionContent>
+          </PromptInputSuggestions>
+        </PromptInputBody>
+      </PromptInput>
+    );
+
+    await vi.waitFor(() => {
+      expect(textarea).toHaveAttribute(
+        "aria-activedescendant",
+        "stable-option"
+      );
+      expect(screen.getByTestId("suggestion-state")).toHaveTextContent(
+        "open::Grace"
+      );
+    });
+    expect(screen.getByRole("option", { name: "Grace" })).toHaveAttribute(
+      "aria-selected",
+      "true"
+    );
+  });
+
+  it("lets onSelect replacement override the default insertion", async () => {
+    setupPromptInputTests();
+    const onSubmit = vi.fn();
+    const onSelect = vi.fn((details: PromptInputSuggestionSelectDetails) => {
+      details.replace("@Grace ");
+    });
+    const user = userEvent.setup();
+
+    render(
+      <PromptInput onSubmit={onSubmit}>
+        <PromptInputBody>
+          <PromptInputSuggestions triggers={PROMPT_INPUT_SUGGESTION_TRIGGERS}>
+            <PromptInputTextarea />
+            <PromptInputSuggestionContent aria-label="Mention suggestions">
+              <PromptInputSuggestionItem onSelect={onSelect} value="Ada">
+                Ada
+              </PromptInputSuggestionItem>
+            </PromptInputSuggestionContent>
+          </PromptInputSuggestions>
+        </PromptInputBody>
+      </PromptInput>
+    );
+
+    const textarea = screen.getByRole("combobox");
+    await user.type(textarea, "@a");
+    await user.keyboard("{Enter}");
+
+    await vi.waitFor(() => {
+      expect(textarea).toHaveValue("@Grace ");
+    });
+    expect(onSelect).toHaveBeenCalledOnce();
+    expect(onSubmit).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/elements/src/prompt-input.tsx
+++ b/packages/elements/src/prompt-input.tsx
@@ -27,6 +27,11 @@ import {
   InputGroupTextarea,
 } from "@repo/shadcn-ui/components/ui/input-group";
 import {
+  Popover,
+  PopoverAnchor,
+  PopoverContent,
+} from "@repo/shadcn-ui/components/ui/popover";
+import {
   Select,
   SelectContent,
   SelectItem,
@@ -51,16 +56,21 @@ import {
 } from "lucide-react";
 import { nanoid } from "nanoid";
 import type {
-  ChangeEvent,
   ChangeEventHandler,
   ClipboardEventHandler,
   ComponentProps,
+  CompositionEventHandler,
   FormEvent,
   FormEventHandler,
+  FocusEventHandler,
   HTMLAttributes,
   KeyboardEventHandler,
+  MouseEventHandler,
+  PointerEventHandler,
   PropsWithChildren,
+  ReactEventHandler,
   ReactNode,
+  Ref,
   RefObject,
 } from "react";
 import {
@@ -69,6 +79,8 @@ import {
   useCallback,
   useContext,
   useEffect,
+  useId,
+  useLayoutEffect,
   useMemo,
   useRef,
   useState,
@@ -77,6 +89,19 @@ import {
 // ============================================================================
 // Helpers
 // ============================================================================
+
+const DEFAULT_SUGGESTION_PREFIXES = [" ", "\n", "\t"] as const;
+
+const setRefValue = <T,>(ref: Ref<T> | undefined, value: T | null): void => {
+  if (typeof ref === "function") {
+    ref(value);
+    return;
+  }
+
+  if (ref) {
+    ref.current = value;
+  }
+};
 
 const convertBlobUrlToDataUrl = async (url: string): Promise<string | null> => {
   try {
@@ -407,6 +432,822 @@ export const usePromptInputReferencedSources = () => {
   }
   return ctx;
 };
+
+// ============================================================================
+// Suggestions
+// ============================================================================
+
+const SUGGESTION_WHITESPACE_REGEX = /\s/u;
+const SUGGESTION_LINE_BREAK_REGEX = /[\r\n]/u;
+
+export interface PromptInputSuggestionRange {
+  start: number;
+  end: number;
+}
+
+export interface PromptInputSuggestionMatch {
+  trigger: string;
+  query: string;
+  range: PromptInputSuggestionRange;
+}
+
+export interface PromptInputSuggestionTrigger {
+  trigger: string;
+  allowSpaces?: boolean;
+  allowedPrefixes?: readonly string[] | null;
+  maxQueryLength?: number;
+  minQueryLength?: number;
+  startOfLine?: boolean;
+}
+
+export interface PromptInputSuggestionSelectDetails {
+  close: () => void;
+  match: PromptInputSuggestionMatch;
+  replace: (text: string) => void;
+  value: string;
+}
+
+export interface PromptInputSuggestionsContextValue {
+  activeValue: string | null;
+  close: () => void;
+  match: PromptInputSuggestionMatch | null;
+  open: boolean;
+  replace: (text: string) => void;
+}
+
+export type PromptInputSuggestionsProps = PropsWithChildren<{
+  onMatchChange?: (match: PromptInputSuggestionMatch | null) => void;
+  onOpenChange?: (open: boolean) => void;
+  triggers: readonly PromptInputSuggestionTrigger[];
+}>;
+
+interface RegisteredSuggestionItem {
+  disabled: boolean;
+  element: RefObject<HTMLButtonElement | null>;
+  id: string;
+  select: () => void;
+  value: string;
+}
+
+interface SuggestionItemUpdate {
+  disabled: boolean;
+  value: string;
+}
+
+interface PromptInputSuggestionsInternalContext extends PromptInputSuggestionsContextValue {
+  activeId: string | null;
+  handleKeyDown: KeyboardEventHandler<HTMLTextAreaElement>;
+  isTextareaTarget: (target: EventTarget | null) => boolean;
+  listboxId: string;
+  registerItem: (item: RegisteredSuggestionItem) => () => void;
+  reset: () => void;
+  setActiveId: (id: string) => void;
+  setFocused: (focused: boolean) => void;
+  setTextarea: (textarea: HTMLTextAreaElement | null) => void;
+  updateItem: (id: string, update: SuggestionItemUpdate) => void;
+  updateMatch: (
+    value: string,
+    selectionStart: number | null,
+    selectionEnd: number | null
+  ) => void;
+}
+
+const PromptInputSuggestionsContext =
+  createContext<PromptInputSuggestionsInternalContext | null>(null);
+
+const usePromptInputSuggestionsInternal = () =>
+  useContext(PromptInputSuggestionsContext);
+
+const usePromptInputSuggestionsContext = () => {
+  const context = usePromptInputSuggestionsInternal();
+  if (!context) {
+    throw new Error(
+      "usePromptInputSuggestions must be used within PromptInputSuggestions"
+    );
+  }
+  return context;
+};
+
+export const usePromptInputSuggestions =
+  (): PromptInputSuggestionsContextValue => usePromptInputSuggestionsContext();
+
+const isSameSuggestionMatch = (
+  first: PromptInputSuggestionMatch | null,
+  second: PromptInputSuggestionMatch | null
+): boolean =>
+  first?.trigger === second?.trigger &&
+  first?.query === second?.query &&
+  first?.range.start === second?.range.start &&
+  first?.range.end === second?.range.end;
+
+const findSuggestionMatch = (
+  value: string,
+  selectionStart: number | null,
+  selectionEnd: number | null,
+  triggers: readonly PromptInputSuggestionTrigger[]
+): PromptInputSuggestionMatch | null => {
+  if (
+    selectionStart === null ||
+    selectionEnd === null ||
+    selectionStart !== selectionEnd
+  ) {
+    return null;
+  }
+
+  const valueBeforeCaret = value.slice(0, selectionStart);
+  let closestMatch: PromptInputSuggestionMatch | null = null;
+
+  for (const configuration of triggers) {
+    const { trigger } = configuration;
+    if (trigger.length === 0) {
+      continue;
+    }
+
+    const triggerIndex = valueBeforeCaret.lastIndexOf(trigger);
+    if (triggerIndex === -1) {
+      continue;
+    }
+
+    const previousCharacter = valueBeforeCaret.at(triggerIndex - 1);
+    const isAtStart = triggerIndex === 0;
+    const hasAllowedPrefix =
+      configuration.allowedPrefixes === null ||
+      isAtStart ||
+      (previousCharacter !== undefined &&
+        (configuration.allowedPrefixes ?? DEFAULT_SUGGESTION_PREFIXES).includes(
+          previousCharacter
+        ));
+    const isAtLineStart = isAtStart || previousCharacter === "\n";
+
+    if (
+      (configuration.startOfLine ? !isAtLineStart : !hasAllowedPrefix) ||
+      (closestMatch && triggerIndex < closestMatch.range.start)
+    ) {
+      continue;
+    }
+
+    const query = valueBeforeCaret.slice(triggerIndex + trigger.length);
+    const containsInvalidWhitespace = configuration.allowSpaces
+      ? SUGGESTION_LINE_BREAK_REGEX.test(query)
+      : SUGGESTION_WHITESPACE_REGEX.test(query);
+    const minQueryLength = configuration.minQueryLength ?? 0;
+
+    if (
+      containsInvalidWhitespace ||
+      query.length < minQueryLength ||
+      (configuration.maxQueryLength !== undefined &&
+        query.length > configuration.maxQueryLength)
+    ) {
+      continue;
+    }
+
+    closestMatch = {
+      query,
+      range: {
+        end: selectionStart,
+        start: triggerIndex,
+      },
+      trigger,
+    };
+  }
+
+  return closestMatch;
+};
+
+const sortSuggestionItems = (
+  items: RegisteredSuggestionItem[]
+): RegisteredSuggestionItem[] =>
+  items.sort((first, second) => {
+    const firstElement = first.element.current;
+    const secondElement = second.element.current;
+    if (!(firstElement && secondElement)) {
+      return 0;
+    }
+
+    const position = firstElement.compareDocumentPosition(secondElement);
+    return position === Node.DOCUMENT_POSITION_FOLLOWING ? -1 : 1;
+  });
+
+export const PromptInputSuggestions = ({
+  children,
+  onMatchChange,
+  onOpenChange,
+  triggers,
+}: PromptInputSuggestionsProps) => {
+  const listboxId = useId();
+  const formRef = useRef<HTMLFormElement | null>(null);
+  const itemsRef = useRef(new Map<string, RegisteredSuggestionItem>());
+  const matchRef = useRef<PromptInputSuggestionMatch | null>(null);
+  const textareaRef = useRef<HTMLTextAreaElement | null>(null);
+  const [activeItem, setActiveItem] = useState<{
+    id: string;
+    value: string;
+  } | null>(null);
+  const [dismissedMatch, setDismissedMatch] = useState<{
+    start: number;
+    trigger: string;
+  } | null>(null);
+  const [focused, setFocused] = useState(false);
+  const [match, setMatch] = useState<PromptInputSuggestionMatch | null>(null);
+  const activeId = activeItem?.id ?? null;
+  const activeValue = activeItem?.value ?? null;
+
+  const activateItem = useCallback((item: RegisteredSuggestionItem) => {
+    setActiveItem((currentActiveItem) =>
+      currentActiveItem?.id === item.id &&
+      currentActiveItem.value === item.value
+        ? currentActiveItem
+        : { id: item.id, value: item.value }
+    );
+  }, []);
+
+  const open = Boolean(
+    focused &&
+    match &&
+    !(
+      dismissedMatch?.start === match.range.start &&
+      dismissedMatch.trigger === match.trigger
+    )
+  );
+
+  const getEnabledItems = useCallback(
+    () =>
+      sortSuggestionItems(
+        [...itemsRef.current.values()].filter(
+          (item) => !item.disabled && item.element.current
+        )
+      ),
+    []
+  );
+
+  const reset = useCallback(() => {
+    matchRef.current = null;
+    setActiveItem(null);
+    setDismissedMatch(null);
+    setMatch(null);
+  }, []);
+
+  const close = useCallback(() => {
+    const currentMatch = matchRef.current;
+    if (currentMatch) {
+      setDismissedMatch({
+        start: currentMatch.range.start,
+        trigger: currentMatch.trigger,
+      });
+    }
+    setActiveItem(null);
+  }, []);
+
+  const isTextareaTarget = useCallback(
+    (target: EventTarget | null) => target === textareaRef.current,
+    []
+  );
+
+  const setTextarea = useCallback(
+    (nextTextarea: HTMLTextAreaElement | null) => {
+      if (!nextTextarea) {
+        textareaRef.current = null;
+        formRef.current?.removeEventListener("reset", reset);
+        formRef.current = null;
+        reset();
+        setFocused(false);
+        return;
+      }
+
+      const nextForm = nextTextarea?.form ?? null;
+      if (formRef.current !== nextForm) {
+        formRef.current?.removeEventListener("reset", reset);
+        nextForm?.addEventListener("reset", reset);
+        formRef.current = nextForm;
+      }
+      textareaRef.current = nextTextarea;
+    },
+    [reset]
+  );
+
+  useEffect(
+    () => () => {
+      formRef.current?.removeEventListener("reset", reset);
+    },
+    [reset]
+  );
+
+  const updateMatch = useCallback(
+    (
+      value: string,
+      selectionStart: number | null,
+      selectionEnd: number | null
+    ) => {
+      const nextMatch = findSuggestionMatch(
+        value,
+        selectionStart,
+        selectionEnd,
+        triggers
+      );
+      const currentMatch = matchRef.current;
+
+      if (isSameSuggestionMatch(currentMatch, nextMatch)) {
+        return;
+      }
+
+      const movedToNewContext =
+        currentMatch?.trigger !== nextMatch?.trigger ||
+        currentMatch?.range.start !== nextMatch?.range.start;
+      if (movedToNewContext) {
+        setActiveItem(null);
+      }
+
+      if (
+        !nextMatch ||
+        dismissedMatch?.trigger !== nextMatch.trigger ||
+        dismissedMatch.start !== nextMatch.range.start
+      ) {
+        setDismissedMatch(null);
+      }
+
+      matchRef.current = nextMatch;
+      setMatch(nextMatch);
+    },
+    [dismissedMatch, triggers]
+  );
+
+  const replace = useCallback(
+    (replacement: string) => {
+      const currentMatch = matchRef.current;
+      const target = textareaRef.current;
+      if (!(currentMatch && target)) {
+        return;
+      }
+
+      const nextValue = `${target.value.slice(
+        0,
+        currentMatch.range.start
+      )}${replacement}${target.value.slice(currentMatch.range.end)}`;
+      const nextCaret = currentMatch.range.start + replacement.length;
+      const valueSetter = Object.getOwnPropertyDescriptor(
+        HTMLTextAreaElement.prototype,
+        "value"
+      )?.set;
+
+      reset();
+      if (valueSetter) {
+        valueSetter.call(target, nextValue);
+      } else {
+        target.value = nextValue;
+      }
+
+      target.focus({ preventScroll: true });
+      target.setSelectionRange(nextCaret, nextCaret);
+      target.dispatchEvent(new Event("input", { bubbles: true }));
+      queueMicrotask(() => target.setSelectionRange(nextCaret, nextCaret));
+    },
+    [reset]
+  );
+
+  const registerItem = useCallback(
+    (item: RegisteredSuggestionItem) => {
+      itemsRef.current.set(item.id, item);
+      setActiveItem((currentActiveItem) => {
+        const currentItem = currentActiveItem
+          ? itemsRef.current.get(currentActiveItem.id)
+          : undefined;
+        const nextItem =
+          currentItem && !currentItem.disabled
+            ? currentItem
+            : getEnabledItems().at(0);
+
+        if (!nextItem) {
+          return null;
+        }
+
+        if (
+          currentActiveItem?.id === nextItem.id &&
+          currentActiveItem.value === nextItem.value
+        ) {
+          return currentActiveItem;
+        }
+
+        return { id: nextItem.id, value: nextItem.value };
+      });
+
+      return () => {
+        itemsRef.current.delete(item.id);
+        setActiveItem((currentActiveItem) => {
+          if (currentActiveItem?.id !== item.id) {
+            return currentActiveItem;
+          }
+
+          const nextItem = getEnabledItems().at(0);
+          return nextItem ? { id: nextItem.id, value: nextItem.value } : null;
+        });
+      };
+    },
+    [getEnabledItems]
+  );
+
+  const updateItem = useCallback(
+    (id: string, update: SuggestionItemUpdate) => {
+      const item = itemsRef.current.get(id);
+      if (!item) {
+        return;
+      }
+
+      item.disabled = update.disabled;
+      item.value = update.value;
+      setActiveItem((currentActiveItem) => {
+        if (!currentActiveItem) {
+          const nextItem = getEnabledItems().at(0);
+          return nextItem ? { id: nextItem.id, value: nextItem.value } : null;
+        }
+
+        if (currentActiveItem.id !== id) {
+          return currentActiveItem;
+        }
+
+        if (update.disabled) {
+          const nextItem = getEnabledItems().at(0);
+          return nextItem ? { id: nextItem.id, value: nextItem.value } : null;
+        }
+
+        return currentActiveItem.value === update.value
+          ? currentActiveItem
+          : { id, value: update.value };
+      });
+    },
+    [getEnabledItems]
+  );
+
+  const setActiveId = useCallback(
+    (id: string) => {
+      const item = itemsRef.current.get(id);
+      if (item && !item.disabled) {
+        activateItem(item);
+      }
+    },
+    [activateItem]
+  );
+
+  const moveActiveItem = useCallback(
+    (direction: 1 | -1): boolean => {
+      const items = getEnabledItems();
+      if (items.length === 0) {
+        return false;
+      }
+
+      const currentIndex = items.findIndex((item) => item.id === activeId);
+      let nextIndex = (currentIndex + direction + items.length) % items.length;
+      if (currentIndex === -1) {
+        nextIndex = direction === 1 ? 0 : items.length - 1;
+      }
+      const nextItem = items[nextIndex];
+      if (!nextItem) {
+        return false;
+      }
+
+      activateItem(nextItem);
+      nextItem.element.current?.scrollIntoView?.({ block: "nearest" });
+      return true;
+    },
+    [activateItem, activeId, getEnabledItems]
+  );
+
+  const handleKeyDown: KeyboardEventHandler<HTMLTextAreaElement> = useCallback(
+    (event) => {
+      if (!open) {
+        return;
+      }
+
+      if (event.key === "ArrowDown" || event.key === "ArrowUp") {
+        if (moveActiveItem(event.key === "ArrowDown" ? 1 : -1)) {
+          event.preventDefault();
+        }
+        return;
+      }
+
+      if (event.key === "Enter" && !event.shiftKey) {
+        const activeItem = activeId
+          ? itemsRef.current.get(activeId)
+          : undefined;
+        if (activeItem && !activeItem.disabled) {
+          event.preventDefault();
+          activeItem.select();
+        }
+        return;
+      }
+
+      if (event.key === "Escape") {
+        event.preventDefault();
+        close();
+        return;
+      }
+
+      if (event.key === "Tab") {
+        close();
+      }
+    },
+    [activeId, close, moveActiveItem, open]
+  );
+
+  const handlePopoverOpenChange = useCallback(
+    (nextOpen: boolean) => {
+      if (!nextOpen) {
+        close();
+      }
+    },
+    [close]
+  );
+
+  const context = useMemo<PromptInputSuggestionsInternalContext>(
+    () => ({
+      activeId,
+      activeValue,
+      close,
+      handleKeyDown,
+      isTextareaTarget,
+      listboxId,
+      match,
+      open,
+      registerItem,
+      replace,
+      reset,
+      setActiveId,
+      setFocused,
+      setTextarea,
+      updateItem,
+      updateMatch,
+    }),
+    [
+      activeId,
+      activeValue,
+      close,
+      handleKeyDown,
+      isTextareaTarget,
+      listboxId,
+      match,
+      open,
+      registerItem,
+      replace,
+      reset,
+      setActiveId,
+      setTextarea,
+      updateItem,
+      updateMatch,
+    ]
+  );
+
+  useEffect(() => onMatchChange?.(match), [match, onMatchChange]);
+  useEffect(() => onOpenChange?.(open), [onOpenChange, open]);
+
+  return (
+    <PromptInputSuggestionsContext.Provider value={context}>
+      <Popover onOpenChange={handlePopoverOpenChange} open={open}>
+        {children}
+      </Popover>
+    </PromptInputSuggestionsContext.Provider>
+  );
+};
+
+export type PromptInputSuggestionContentProps = ComponentProps<
+  typeof PopoverContent
+>;
+
+export const PromptInputSuggestionContent = ({
+  "aria-label": ariaLabel = "Suggestions",
+  align = "start",
+  className,
+  onCloseAutoFocus,
+  onInteractOutside,
+  onOpenAutoFocus,
+  side = "top",
+  sideOffset = 8,
+  ...props
+}: PromptInputSuggestionContentProps) => {
+  const context = usePromptInputSuggestionsContext();
+  const { isTextareaTarget } = context;
+
+  const handleCloseAutoFocus = useCallback<
+    NonNullable<PromptInputSuggestionContentProps["onCloseAutoFocus"]>
+  >(
+    (event) => {
+      onCloseAutoFocus?.(event);
+      if (!event.defaultPrevented) {
+        event.preventDefault();
+      }
+    },
+    [onCloseAutoFocus]
+  );
+
+  const handleInteractOutside = useCallback<
+    NonNullable<PromptInputSuggestionContentProps["onInteractOutside"]>
+  >(
+    (event) => {
+      onInteractOutside?.(event);
+      if (isTextareaTarget(event.detail.originalEvent.target)) {
+        event.preventDefault();
+      }
+    },
+    [isTextareaTarget, onInteractOutside]
+  );
+
+  const handleOpenAutoFocus = useCallback<
+    NonNullable<PromptInputSuggestionContentProps["onOpenAutoFocus"]>
+  >(
+    (event) => {
+      onOpenAutoFocus?.(event);
+      if (!event.defaultPrevented) {
+        event.preventDefault();
+      }
+    },
+    [onOpenAutoFocus]
+  );
+
+  return (
+    <PopoverContent
+      {...props}
+      align={align}
+      aria-label={ariaLabel}
+      className={cn("max-h-72 w-80 overflow-y-auto p-1", className)}
+      id={context.listboxId}
+      onCloseAutoFocus={handleCloseAutoFocus}
+      onInteractOutside={handleInteractOutside}
+      onOpenAutoFocus={handleOpenAutoFocus}
+      role="listbox"
+      side={side}
+      sideOffset={sideOffset}
+    />
+  );
+};
+
+export type PromptInputSuggestionItemProps = Omit<
+  ComponentProps<"button">,
+  "onSelect" | "value"
+> & {
+  onSelect?: (details: PromptInputSuggestionSelectDetails) => void;
+  replaceWith?:
+    | string
+    | false
+    | ((match: PromptInputSuggestionMatch) => string);
+  value: string;
+};
+
+export const PromptInputSuggestionItem = ({
+  children,
+  className,
+  disabled = false,
+  id: idProp,
+  onClick,
+  onPointerDown,
+  onPointerMove,
+  onSelect,
+  ref,
+  replaceWith,
+  value,
+  ...props
+}: PromptInputSuggestionItemProps) => {
+  const context = usePromptInputSuggestionsContext();
+  const { close, match, registerItem, replace, setActiveId, updateItem } =
+    context;
+
+  const generatedId = useId();
+  const id = idProp ?? generatedId;
+  const disabledRef = useRef(disabled);
+  const elementRef = useRef<HTMLButtonElement | null>(null);
+  const valueRef = useRef(value);
+  const isActive = context.activeId === id;
+
+  const select = useCallback(() => {
+    if (!match || disabled) {
+      return;
+    }
+
+    let didReplace = false;
+    const replaceSelection = (replacement: string) => {
+      didReplace = true;
+      replace(replacement);
+    };
+
+    onSelect?.({
+      close,
+      match,
+      replace: replaceSelection,
+      value,
+    });
+
+    if (replaceWith !== false && !didReplace) {
+      const replacement =
+        typeof replaceWith === "function"
+          ? replaceWith(match)
+          : (replaceWith ?? `${match.trigger}${value} `);
+      replace(replacement);
+    }
+    close();
+  }, [close, disabled, match, onSelect, replace, replaceWith, value]);
+
+  const selectRef = useRef(select);
+
+  useLayoutEffect(() => {
+    selectRef.current = select;
+  }, [select]);
+
+  useLayoutEffect(
+    () =>
+      registerItem({
+        disabled: disabledRef.current,
+        element: elementRef,
+        id,
+        select: () => selectRef.current(),
+        value: valueRef.current,
+      }),
+    [id, registerItem]
+  );
+
+  useLayoutEffect(() => {
+    disabledRef.current = disabled;
+    valueRef.current = value;
+    updateItem(id, { disabled, value });
+  }, [disabled, id, updateItem, value]);
+
+  const handleClick: MouseEventHandler<HTMLButtonElement> = useCallback(
+    (event) => {
+      onClick?.(event);
+      if (!event.defaultPrevented) {
+        select();
+      }
+    },
+    [onClick, select]
+  );
+
+  const handlePointerDown: PointerEventHandler<HTMLButtonElement> = useCallback(
+    (event) => {
+      onPointerDown?.(event);
+      if (!event.defaultPrevented && !disabled) {
+        event.preventDefault();
+      }
+    },
+    [disabled, onPointerDown]
+  );
+
+  const handlePointerMove: PointerEventHandler<HTMLButtonElement> = useCallback(
+    (event) => {
+      onPointerMove?.(event);
+      if (!event.defaultPrevented && !disabled) {
+        setActiveId(id);
+      }
+    },
+    [disabled, id, onPointerMove, setActiveId]
+  );
+
+  const handleRef = useCallback(
+    (element: HTMLButtonElement | null) => {
+      elementRef.current = element;
+      setRefValue(ref, element);
+    },
+    [ref]
+  );
+
+  return (
+    <button
+      {...props}
+      aria-selected={isActive}
+      className={cn(
+        "relative flex w-full cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-left text-sm outline-hidden",
+        "hover:bg-accent hover:text-accent-foreground",
+        "data-[active=true]:bg-accent data-[active=true]:text-accent-foreground",
+        "disabled:pointer-events-none disabled:opacity-50",
+        className
+      )}
+      data-active={isActive}
+      disabled={disabled}
+      id={id}
+      onClick={handleClick}
+      onPointerDown={handlePointerDown}
+      onPointerMove={handlePointerMove}
+      ref={handleRef}
+      role="option"
+      tabIndex={-1}
+      type="button"
+    >
+      {children}
+    </button>
+  );
+};
+
+export type PromptInputSuggestionEmptyProps = HTMLAttributes<HTMLDivElement>;
+
+export const PromptInputSuggestionEmpty = ({
+  className,
+  role = "status",
+  ...props
+}: PromptInputSuggestionEmptyProps) => (
+  <div
+    {...props}
+    className={cn(
+      "px-2 py-6 text-center text-muted-foreground text-sm",
+      className
+    )}
+    role={role}
+  />
+);
 
 export type PromptInputActionAddAttachmentsProps = ComponentProps<
   typeof DropdownMenuItem
@@ -954,37 +1795,89 @@ export type PromptInputTextareaProps = ComponentProps<
 >;
 
 export const PromptInputTextarea = ({
-  onChange,
-  onKeyDown,
+  "aria-activedescendant": ariaActiveDescendant,
+  "aria-autocomplete": ariaAutocomplete,
+  "aria-controls": ariaControls,
+  "aria-expanded": ariaExpanded,
+  "aria-haspopup": ariaHasPopup,
   className,
+  name = "message",
+  onBlur,
+  onChange,
+  onCompositionEnd,
+  onCompositionStart,
+  onFocus,
+  onKeyDown,
+  onPaste,
+  onSelect,
   placeholder = "What would you like to know?",
+  ref,
+  role,
+  value,
   ...props
 }: PromptInputTextareaProps) => {
   const controller = useOptionalPromptInputController();
   const attachments = usePromptInputAttachments();
-  const [isComposing, setIsComposing] = useState(false);
+  const suggestions = usePromptInputSuggestionsInternal();
+  const handleSuggestionKeyDown = suggestions?.handleKeyDown;
+  const resetSuggestions = suggestions?.reset;
+  const setSuggestionFocused = suggestions?.setFocused;
+  const setSuggestionTextarea = suggestions?.setTextarea;
+  const updateSuggestionMatch = suggestions?.updateMatch;
+  const isComposingRef = useRef(false);
+  const textareaRef = useRef<HTMLTextAreaElement | null>(null);
+
+  const handleRef = useCallback(
+    (textarea: HTMLTextAreaElement | null) => {
+      textareaRef.current = textarea;
+      if (textarea) {
+        setSuggestionTextarea?.(textarea);
+      }
+      setRefValue(ref, textarea);
+    },
+    [ref, setSuggestionTextarea]
+  );
+
+  const updateSuggestions = useCallback(
+    (textarea: HTMLTextAreaElement) => {
+      updateSuggestionMatch?.(
+        textarea.value,
+        textarea.selectionStart,
+        textarea.selectionEnd
+      );
+    },
+    [updateSuggestionMatch]
+  );
 
   const handleKeyDown: KeyboardEventHandler<HTMLTextAreaElement> = useCallback(
-    (e) => {
+    (event) => {
+      setSuggestionTextarea?.(event.currentTarget);
+
       // Call the external onKeyDown handler first
-      onKeyDown?.(e);
+      onKeyDown?.(event);
 
       // If the external handler prevented default, don't run internal logic
-      if (e.defaultPrevented) {
+      if (event.defaultPrevented) {
         return;
       }
 
-      if (e.key === "Enter") {
-        if (isComposing || e.nativeEvent.isComposing) {
+      if (isComposingRef.current || event.nativeEvent.isComposing) {
+        return;
+      }
+
+      handleSuggestionKeyDown?.(event);
+      if (event.defaultPrevented) {
+        return;
+      }
+
+      if (event.key === "Enter") {
+        if (event.shiftKey) {
           return;
         }
-        if (e.shiftKey) {
-          return;
-        }
-        e.preventDefault();
+        event.preventDefault();
 
         // Check if the submit button is disabled before submitting
-        const { form } = e.currentTarget;
+        const { form } = event.currentTarget;
         const submitButton = form?.querySelector(
           'button[type="submit"]'
         ) as HTMLButtonElement | null;
@@ -997,22 +1890,27 @@ export const PromptInputTextarea = ({
 
       // Remove last attachment when Backspace is pressed and textarea is empty
       if (
-        e.key === "Backspace" &&
-        e.currentTarget.value === "" &&
+        event.key === "Backspace" &&
+        event.currentTarget.value === "" &&
         attachments.files.length > 0
       ) {
-        e.preventDefault();
+        event.preventDefault();
         const lastAttachment = attachments.files.at(-1);
         if (lastAttachment) {
           attachments.remove(lastAttachment.id);
         }
       }
     },
-    [onKeyDown, isComposing, attachments]
+    [attachments, handleSuggestionKeyDown, onKeyDown, setSuggestionTextarea]
   );
 
   const handlePaste: ClipboardEventHandler<HTMLTextAreaElement> = useCallback(
     (event) => {
+      onPaste?.(event);
+      if (event.defaultPrevented) {
+        return;
+      }
+
       const items = event.clipboardData?.items;
 
       if (!items) {
@@ -1035,36 +1933,124 @@ export const PromptInputTextarea = ({
         attachments.add(files);
       }
     },
-    [attachments]
+    [attachments, onPaste]
   );
 
-  const handleCompositionEnd = useCallback(() => setIsComposing(false), []);
-  const handleCompositionStart = useCallback(() => setIsComposing(true), []);
+  const handleChange: ChangeEventHandler<HTMLTextAreaElement> = useCallback(
+    (event) => {
+      controller?.textInput.setInput(event.currentTarget.value);
+      onChange?.(event);
 
-  const controlledProps = controller
-    ? {
-        onChange: (e: ChangeEvent<HTMLTextAreaElement>) => {
-          controller.textInput.setInput(e.currentTarget.value);
-          onChange?.(e);
-        },
-        value: controller.textInput.value,
+      const nativeEventIsComposing =
+        "isComposing" in event.nativeEvent &&
+        event.nativeEvent.isComposing === true;
+      if (!(isComposingRef.current || nativeEventIsComposing)) {
+        updateSuggestions(event.currentTarget);
       }
-    : {
-        onChange,
-      };
+    },
+    [controller, onChange, updateSuggestions]
+  );
 
-  return (
+  const handleCompositionStart: CompositionEventHandler<HTMLTextAreaElement> =
+    useCallback(
+      (event) => {
+        onCompositionStart?.(event);
+        isComposingRef.current = true;
+        resetSuggestions?.();
+      },
+      [onCompositionStart, resetSuggestions]
+    );
+
+  const handleCompositionEnd: CompositionEventHandler<HTMLTextAreaElement> =
+    useCallback(
+      (event) => {
+        onCompositionEnd?.(event);
+        isComposingRef.current = false;
+        updateSuggestions(event.currentTarget);
+      },
+      [onCompositionEnd, updateSuggestions]
+    );
+
+  const handleFocus: FocusEventHandler<HTMLTextAreaElement> = useCallback(
+    (event) => {
+      onFocus?.(event);
+      setSuggestionTextarea?.(event.currentTarget);
+      setSuggestionFocused?.(true);
+      updateSuggestions(event.currentTarget);
+    },
+    [onFocus, setSuggestionFocused, setSuggestionTextarea, updateSuggestions]
+  );
+
+  const handleBlur: FocusEventHandler<HTMLTextAreaElement> = useCallback(
+    (event) => {
+      onBlur?.(event);
+      setSuggestionFocused?.(false);
+    },
+    [onBlur, setSuggestionFocused]
+  );
+
+  const handleSelect: ReactEventHandler<HTMLTextAreaElement> = useCallback(
+    (event) => {
+      onSelect?.(event);
+      if (!isComposingRef.current) {
+        updateSuggestions(event.currentTarget);
+      }
+    },
+    [onSelect, updateSuggestions]
+  );
+
+  useEffect(
+    () => () => {
+      setSuggestionTextarea?.(null);
+    },
+    [setSuggestionTextarea]
+  );
+
+  useEffect(() => {
+    const textarea = textareaRef.current;
+    if (textarea) {
+      updateSuggestions(textarea);
+    }
+  }, [controller?.textInput.value, updateSuggestions, value]);
+
+  const textarea = (
     <InputGroupTextarea
+      {...props}
+      aria-activedescendant={
+        ariaActiveDescendant ??
+        (suggestions?.open ? (suggestions.activeId ?? undefined) : undefined)
+      }
+      aria-autocomplete={ariaAutocomplete ?? (suggestions ? "list" : undefined)}
+      aria-controls={
+        ariaControls ?? (suggestions ? suggestions.listboxId : undefined)
+      }
+      aria-expanded={
+        ariaExpanded ?? (suggestions ? suggestions.open : undefined)
+      }
+      aria-haspopup={ariaHasPopup ?? (suggestions ? "listbox" : undefined)}
       className={cn("field-sizing-content max-h-48 min-h-16", className)}
-      name="message"
+      name={name}
+      onBlur={handleBlur}
+      onChange={handleChange}
       onCompositionEnd={handleCompositionEnd}
       onCompositionStart={handleCompositionStart}
+      onFocus={handleFocus}
       onKeyDown={handleKeyDown}
       onPaste={handlePaste}
+      onSelect={handleSelect}
       placeholder={placeholder}
-      {...props}
-      {...controlledProps}
+      ref={handleRef}
+      role={role ?? (suggestions ? "combobox" : undefined)}
+      value={controller ? controller.textInput.value : value}
     />
+  );
+
+  return suggestions ? (
+    <PopoverAnchor asChild data-slot="input-group-control">
+      {textarea}
+    </PopoverAnchor>
+  ) : (
+    textarea
   );
 };
 

--- a/packages/examples/src/prompt-input.tsx
+++ b/packages/examples/src/prompt-input.tsx
@@ -19,7 +19,10 @@ import {
   ModelSelectorName,
   ModelSelectorTrigger,
 } from "@repo/elements/model-selector";
-import type { PromptInputMessage } from "@repo/elements/prompt-input";
+import type {
+  PromptInputMessage,
+  PromptInputSuggestionTrigger,
+} from "@repo/elements/prompt-input";
 import {
   PromptInput,
   PromptInputActionAddAttachments,
@@ -31,10 +34,15 @@ import {
   PromptInputButton,
   PromptInputFooter,
   PromptInputProvider,
+  PromptInputSuggestionContent,
+  PromptInputSuggestionEmpty,
+  PromptInputSuggestionItem,
+  PromptInputSuggestions,
   PromptInputSubmit,
   PromptInputTextarea,
   PromptInputTools,
   usePromptInputAttachments,
+  usePromptInputSuggestions,
 } from "@repo/elements/prompt-input";
 import { CheckIcon, GlobeIcon } from "lucide-react";
 import { memo, useCallback, useState } from "react";
@@ -79,6 +87,53 @@ const models = [
 
 const SUBMITTING_TIMEOUT = 200;
 const STREAMING_TIMEOUT = 2000;
+
+interface PromptSuggestion {
+  description: string;
+  label: string;
+  value: string;
+}
+
+const fileSuggestions: PromptSuggestion[] = [
+  {
+    description: "Prompt composer and suggestion primitives",
+    label: "prompt-input.tsx",
+    value: "packages/elements/src/prompt-input.tsx",
+  },
+  {
+    description: "Conversation layout and scroll behavior",
+    label: "conversation.tsx",
+    value: "packages/elements/src/conversation.tsx",
+  },
+  {
+    description: "Chat message rendering components",
+    label: "message.tsx",
+    value: "packages/elements/src/message.tsx",
+  },
+];
+
+const commandSuggestions: PromptSuggestion[] = [
+  {
+    description: "Search project files and documentation",
+    label: "Search",
+    value: "search",
+  },
+  {
+    description: "Summarize the current conversation",
+    label: "Summarize",
+    value: "summarize",
+  },
+  {
+    description: "Explain the selected code or concept",
+    label: "Explain",
+    value: "explain",
+  },
+];
+
+const suggestionTriggers = [
+  { trigger: "@" },
+  { startOfLine: true, trigger: "/" },
+] satisfies readonly PromptInputSuggestionTrigger[];
 
 interface AttachmentItemProps {
   attachment: {
@@ -159,6 +214,60 @@ const PromptInputAttachmentsDisplay = () => {
   );
 };
 
+const PromptInputSuggestionsDisplay = () => {
+  const { match } = usePromptInputSuggestions();
+
+  if (!match) {
+    return null;
+  }
+
+  const suggestions =
+    match.trigger === "@" ? fileSuggestions : commandSuggestions;
+  const normalizedQuery = match.query.toLowerCase();
+  const filteredSuggestions = suggestions.filter((suggestion) =>
+    `${suggestion.label} ${suggestion.value} ${suggestion.description}`
+      .toLowerCase()
+      .includes(normalizedQuery)
+  );
+  const groupLabel = match.trigger === "@" ? "Files" : "Commands";
+
+  return (
+    <PromptInputSuggestionContent aria-label={`${groupLabel} suggestions`}>
+      <div className="flex items-center justify-between px-2 py-1.5 text-muted-foreground text-xs">
+        <span>{groupLabel}</span>
+        <span>Use arrow keys to navigate</span>
+      </div>
+      {filteredSuggestions.length > 0 ? (
+        filteredSuggestions.map((suggestion) => (
+          <PromptInputSuggestionItem
+            key={suggestion.value}
+            value={suggestion.value}
+          >
+            <span
+              aria-hidden="true"
+              className="flex size-6 shrink-0 items-center justify-center rounded-md bg-muted font-medium text-muted-foreground text-xs"
+            >
+              {match.trigger}
+            </span>
+            <span className="min-w-0">
+              <span className="block truncate font-medium">
+                {suggestion.label}
+              </span>
+              <span className="block truncate text-muted-foreground text-xs">
+                {suggestion.description}
+              </span>
+            </span>
+          </PromptInputSuggestionItem>
+        ))
+      ) : (
+        <PromptInputSuggestionEmpty>
+          No {groupLabel.toLowerCase()} found.
+        </PromptInputSuggestionEmpty>
+      )}
+    </PromptInputSuggestionContent>
+  );
+};
+
 const Example = () => {
   const [model, setModel] = useState<string>(models[0].id);
   const [modelSelectorOpen, setModelSelectorOpen] = useState(false);
@@ -198,67 +307,70 @@ const Example = () => {
   return (
     <div className="size-full">
       <PromptInputProvider>
-        <PromptInput globalDrop multiple onSubmit={handleSubmit}>
-          <PromptInputAttachmentsDisplay />
-          <PromptInputBody>
-            <PromptInputTextarea />
-          </PromptInputBody>
-          <PromptInputFooter>
-            <PromptInputTools>
-              <PromptInputActionMenu>
-                <PromptInputActionMenuTrigger />
-                <PromptInputActionMenuContent>
-                  <PromptInputActionAddAttachments />
-                  <PromptInputActionAddScreenshot />
-                </PromptInputActionMenuContent>
-              </PromptInputActionMenu>
-              <PromptInputButton>
-                <GlobeIcon size={16} />
-                <span>Search</span>
-              </PromptInputButton>
-              <ModelSelector
-                onOpenChange={setModelSelectorOpen}
-                open={modelSelectorOpen}
-              >
-                <ModelSelectorTrigger asChild>
-                  <PromptInputButton>
-                    {selectedModelData?.chefSlug && (
-                      <ModelSelectorLogo
-                        provider={selectedModelData.chefSlug}
-                      />
-                    )}
-                    {selectedModelData?.name && (
-                      <ModelSelectorName>
-                        {selectedModelData.name}
-                      </ModelSelectorName>
-                    )}
-                  </PromptInputButton>
-                </ModelSelectorTrigger>
-                <ModelSelectorContent>
-                  <ModelSelectorInput placeholder="Search models..." />
-                  <ModelSelectorList>
-                    <ModelSelectorEmpty>No models found.</ModelSelectorEmpty>
-                    {["OpenAI", "Anthropic", "Google"].map((chef) => (
-                      <ModelSelectorGroup heading={chef} key={chef}>
-                        {models
-                          .filter((m) => m.chef === chef)
-                          .map((m) => (
-                            <ModelItem
-                              key={m.id}
-                              m={m}
-                              onSelect={handleModelSelect}
-                              selectedModel={model}
-                            />
-                          ))}
-                      </ModelSelectorGroup>
-                    ))}
-                  </ModelSelectorList>
-                </ModelSelectorContent>
-              </ModelSelector>
-            </PromptInputTools>
-            <PromptInputSubmit status={status} />
-          </PromptInputFooter>
-        </PromptInput>
+        <PromptInputSuggestions triggers={suggestionTriggers}>
+          <PromptInput globalDrop multiple onSubmit={handleSubmit}>
+            <PromptInputAttachmentsDisplay />
+            <PromptInputBody>
+              <PromptInputTextarea placeholder="Ask anything, type @ for files or / for commands" />
+            </PromptInputBody>
+            <PromptInputFooter>
+              <PromptInputTools>
+                <PromptInputActionMenu>
+                  <PromptInputActionMenuTrigger />
+                  <PromptInputActionMenuContent>
+                    <PromptInputActionAddAttachments />
+                    <PromptInputActionAddScreenshot />
+                  </PromptInputActionMenuContent>
+                </PromptInputActionMenu>
+                <PromptInputButton>
+                  <GlobeIcon size={16} />
+                  <span>Search</span>
+                </PromptInputButton>
+                <ModelSelector
+                  onOpenChange={setModelSelectorOpen}
+                  open={modelSelectorOpen}
+                >
+                  <ModelSelectorTrigger asChild>
+                    <PromptInputButton>
+                      {selectedModelData?.chefSlug && (
+                        <ModelSelectorLogo
+                          provider={selectedModelData.chefSlug}
+                        />
+                      )}
+                      {selectedModelData?.name && (
+                        <ModelSelectorName>
+                          {selectedModelData.name}
+                        </ModelSelectorName>
+                      )}
+                    </PromptInputButton>
+                  </ModelSelectorTrigger>
+                  <ModelSelectorContent>
+                    <ModelSelectorInput placeholder="Search models..." />
+                    <ModelSelectorList>
+                      <ModelSelectorEmpty>No models found.</ModelSelectorEmpty>
+                      {["OpenAI", "Anthropic", "Google"].map((chef) => (
+                        <ModelSelectorGroup heading={chef} key={chef}>
+                          {models
+                            .filter((m) => m.chef === chef)
+                            .map((m) => (
+                              <ModelItem
+                                key={m.id}
+                                m={m}
+                                onSelect={handleModelSelect}
+                                selectedModel={model}
+                              />
+                            ))}
+                        </ModelSelectorGroup>
+                      ))}
+                    </ModelSelectorList>
+                  </ModelSelectorContent>
+                </ModelSelector>
+              </PromptInputTools>
+              <PromptInputSubmit status={status} />
+            </PromptInputFooter>
+          </PromptInput>
+          <PromptInputSuggestionsDisplay />
+        </PromptInputSuggestions>
       </PromptInputProvider>
     </div>
   );

--- a/skills/ai-elements/references/prompt-input.md
+++ b/skills/ai-elements/references/prompt-input.md
@@ -237,11 +237,68 @@ export async function POST(req: Request) {
 }
 ```
 
+## Mentions and slash commands
+
+Wrap the prompt in `PromptInputSuggestions` to open a keyboard-accessible suggestion list when the user types a configured trigger. The hook exposes the active trigger and query so you can filter local or remote results.
+
+Suggestions replace text in the existing textarea, so the prompt's plain-text submission contract remains unchanged.
+
+```tsx
+const files = [
+  "packages/elements/src/prompt-input.tsx",
+  "packages/elements/src/message.tsx",
+];
+const commands = ["search", "summarize", "explain"];
+const triggers = [{ trigger: "@" }, { trigger: "/", startOfLine: true }];
+
+const SuggestionMenu = () => {
+  const { match } = usePromptInputSuggestions();
+
+  if (!match) {
+    return null;
+  }
+
+  const items = match.trigger === "@" ? files : commands;
+  const filteredItems = items.filter((item) =>
+    item.toLowerCase().includes(match.query.toLowerCase())
+  );
+
+  return (
+    <PromptInputSuggestionContent>
+      {filteredItems.length > 0 ? (
+        filteredItems.map((item) => (
+          <PromptInputSuggestionItem key={item} value={item}>
+            {match.trigger}
+            {item}
+          </PromptInputSuggestionItem>
+        ))
+      ) : (
+        <PromptInputSuggestionEmpty>
+          No results found.
+        </PromptInputSuggestionEmpty>
+      )}
+    </PromptInputSuggestionContent>
+  );
+};
+
+<PromptInputSuggestions triggers={triggers}>
+  <PromptInput onSubmit={handleSubmit}>
+    <PromptInputBody>
+      <PromptInputTextarea placeholder="Type @ for files or / for commands" />
+    </PromptInputBody>
+  </PromptInput>
+  <SuggestionMenu />
+</PromptInputSuggestions>;
+```
+
+By default, selecting an item replaces the active query with its trigger and value followed by a space. Use `replaceWith` or `onSelect` on `PromptInputSuggestionItem` when you need custom insertion or selection behavior.
+
 ## Features
 
 - Auto-resizing textarea that adjusts height based on content
 - File attachment support with drag-and-drop
 - Built-in screenshot capture action
+- Contextual `@` mentions and `/` slash-command suggestions
 - Image preview for image attachments
 - Configurable file constraints (max files, max size, accepted types)
 - Automatic submit button icons based on status
@@ -291,6 +348,57 @@ See `scripts/prompt-input-tooltip.tsx` for this example.
 | Prop | Type | Default | Description |
 |------|------|---------|-------------|
 | `...props` | `React.ComponentProps<typeof Textarea>` | - | Any other props are spread to the underlying Textarea component. |
+
+### `<PromptInputSuggestions />`
+
+Provides suggestion state and connects a descendant `PromptInputTextarea` to the suggestion content.
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `triggers` | `readonly PromptInputSuggestionTrigger[]` | Required | Trigger configurations that activate suggestions. |
+| `onMatchChange` | `PromptInputSuggestionMatch change callback` | - | Called when the active trigger, query, or range changes. |
+| `onOpenChange` | `(open: boolean) => void` | - | Called when the suggestion popover opens or closes. |
+| `children` | `React.ReactNode` | - | The prompt input and suggestion content. |
+
+#### `PromptInputSuggestionTrigger`
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `trigger` | `string` | Required | Text that activates suggestions, for example an at sign or slash. |
+| `allowSpaces` | `boolean` | `false` | Whether the active query may contain spaces. |
+| `allowedPrefixes` | `readonly string array or null` | `space, newline, or tab` | Characters allowed immediately before the trigger. Use null to allow any prefix. |
+| `minQueryLength` | `number` | `0` | Minimum query length required before matching. |
+| `maxQueryLength` | `number` | - | Maximum query length that remains active. |
+| `startOfLine` | `boolean` | `false` | Whether the trigger must appear at the start of a line. |
+
+### `<PromptInputSuggestionContent />`
+
+Portal-backed listbox positioned relative to the prompt textarea.
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `aria-label` | `string` | `Suggestions` | Accessible label for the suggestion listbox. |
+| `align` | `start, center, or end` | `start` | Alignment relative to the textarea. |
+| `side` | `top, right, bottom, or left` | `top` | Preferred side of the textarea. |
+| `sideOffset` | `number` | `8` | Distance from the textarea in pixels. |
+| `...props` | `React.ComponentProps<typeof PopoverContent>` | - | Any other props are spread to PopoverContent. |
+
+### `<PromptInputSuggestionItem />`
+
+Keyboard- and pointer-selectable suggestion option. The default replacement is `{trigger}{value} `.
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `value` | `string` | Required | Value used for navigation state and default insertion. |
+| `replaceWith` | `string, false, or replacement function` | - | Custom replacement text or function. Set false to handle insertion yourself. |
+| `onSelect` | `(details: PromptInputSuggestionSelectDetails) => void` | - | Called with the selected value, match, and replacement helpers. |
+| `...props` | `React button props except onSelect and value` | - | Any other props are spread to the underlying button. |
+
+### `<PromptInputSuggestionEmpty />`
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `...props` | `React.HTMLAttributes<HTMLDivElement>` | - | Any other props are spread to the empty-state div. |
 
 ### `<PromptInputFooter />`
 
@@ -524,6 +632,23 @@ Optional global provider that lifts PromptInput state outside of PromptInput. Wh
 | `...props` | `React.ComponentProps<typeof CommandSeparator>` | - | Any other props are spread to the CommandSeparator component. |
 
 ## Hooks
+
+### `usePromptInputSuggestions`
+
+Access the active suggestion state within `PromptInputSuggestions`.
+
+```tsx
+const { activeValue, close, match, open, replace } =
+  usePromptInputSuggestions();
+
+match?.trigger; // Active trigger
+match?.query; // Text after the trigger
+match?.range; // Trigger-to-caret replacement range
+activeValue; // Value of the keyboard-highlighted item
+open; // Whether the suggestion list is open
+replace("@replacement "); // Replace the active range and restore focus
+close(); // Dismiss the current match
+```
 
 ### `usePromptInputAttachments`
 

--- a/skills/ai-elements/scripts/prompt-input.tsx
+++ b/skills/ai-elements/scripts/prompt-input.tsx
@@ -19,7 +19,10 @@ import {
   ModelSelectorName,
   ModelSelectorTrigger,
 } from "@/components/ai-elements/model-selector";
-import type { PromptInputMessage } from "@/components/ai-elements/prompt-input";
+import type {
+  PromptInputMessage,
+  PromptInputSuggestionTrigger,
+} from "@/components/ai-elements/prompt-input";
 import {
   PromptInput,
   PromptInputActionAddAttachments,
@@ -31,10 +34,15 @@ import {
   PromptInputButton,
   PromptInputFooter,
   PromptInputProvider,
+  PromptInputSuggestionContent,
+  PromptInputSuggestionEmpty,
+  PromptInputSuggestionItem,
+  PromptInputSuggestions,
   PromptInputSubmit,
   PromptInputTextarea,
   PromptInputTools,
   usePromptInputAttachments,
+  usePromptInputSuggestions,
 } from "@/components/ai-elements/prompt-input";
 import { CheckIcon, GlobeIcon } from "lucide-react";
 import { memo, useCallback, useState } from "react";
@@ -79,6 +87,53 @@ const models = [
 
 const SUBMITTING_TIMEOUT = 200;
 const STREAMING_TIMEOUT = 2000;
+
+interface PromptSuggestion {
+  description: string;
+  label: string;
+  value: string;
+}
+
+const fileSuggestions: PromptSuggestion[] = [
+  {
+    description: "Prompt composer and suggestion primitives",
+    label: "prompt-input.tsx",
+    value: "packages/elements/src/prompt-input.tsx",
+  },
+  {
+    description: "Conversation layout and scroll behavior",
+    label: "conversation.tsx",
+    value: "packages/elements/src/conversation.tsx",
+  },
+  {
+    description: "Chat message rendering components",
+    label: "message.tsx",
+    value: "packages/elements/src/message.tsx",
+  },
+];
+
+const commandSuggestions: PromptSuggestion[] = [
+  {
+    description: "Search project files and documentation",
+    label: "Search",
+    value: "search",
+  },
+  {
+    description: "Summarize the current conversation",
+    label: "Summarize",
+    value: "summarize",
+  },
+  {
+    description: "Explain the selected code or concept",
+    label: "Explain",
+    value: "explain",
+  },
+];
+
+const suggestionTriggers = [
+  { trigger: "@" },
+  { startOfLine: true, trigger: "/" },
+] satisfies readonly PromptInputSuggestionTrigger[];
 
 interface AttachmentItemProps {
   attachment: {
@@ -159,6 +214,60 @@ const PromptInputAttachmentsDisplay = () => {
   );
 };
 
+const PromptInputSuggestionsDisplay = () => {
+  const { match } = usePromptInputSuggestions();
+
+  if (!match) {
+    return null;
+  }
+
+  const suggestions =
+    match.trigger === "@" ? fileSuggestions : commandSuggestions;
+  const normalizedQuery = match.query.toLowerCase();
+  const filteredSuggestions = suggestions.filter((suggestion) =>
+    `${suggestion.label} ${suggestion.value} ${suggestion.description}`
+      .toLowerCase()
+      .includes(normalizedQuery)
+  );
+  const groupLabel = match.trigger === "@" ? "Files" : "Commands";
+
+  return (
+    <PromptInputSuggestionContent aria-label={`${groupLabel} suggestions`}>
+      <div className="flex items-center justify-between px-2 py-1.5 text-muted-foreground text-xs">
+        <span>{groupLabel}</span>
+        <span>Use arrow keys to navigate</span>
+      </div>
+      {filteredSuggestions.length > 0 ? (
+        filteredSuggestions.map((suggestion) => (
+          <PromptInputSuggestionItem
+            key={suggestion.value}
+            value={suggestion.value}
+          >
+            <span
+              aria-hidden="true"
+              className="flex size-6 shrink-0 items-center justify-center rounded-md bg-muted font-medium text-muted-foreground text-xs"
+            >
+              {match.trigger}
+            </span>
+            <span className="min-w-0">
+              <span className="block truncate font-medium">
+                {suggestion.label}
+              </span>
+              <span className="block truncate text-muted-foreground text-xs">
+                {suggestion.description}
+              </span>
+            </span>
+          </PromptInputSuggestionItem>
+        ))
+      ) : (
+        <PromptInputSuggestionEmpty>
+          No {groupLabel.toLowerCase()} found.
+        </PromptInputSuggestionEmpty>
+      )}
+    </PromptInputSuggestionContent>
+  );
+};
+
 const Example = () => {
   const [model, setModel] = useState<string>(models[0].id);
   const [modelSelectorOpen, setModelSelectorOpen] = useState(false);
@@ -198,67 +307,70 @@ const Example = () => {
   return (
     <div className="size-full">
       <PromptInputProvider>
-        <PromptInput globalDrop multiple onSubmit={handleSubmit}>
-          <PromptInputAttachmentsDisplay />
-          <PromptInputBody>
-            <PromptInputTextarea />
-          </PromptInputBody>
-          <PromptInputFooter>
-            <PromptInputTools>
-              <PromptInputActionMenu>
-                <PromptInputActionMenuTrigger />
-                <PromptInputActionMenuContent>
-                  <PromptInputActionAddAttachments />
-                  <PromptInputActionAddScreenshot />
-                </PromptInputActionMenuContent>
-              </PromptInputActionMenu>
-              <PromptInputButton>
-                <GlobeIcon size={16} />
-                <span>Search</span>
-              </PromptInputButton>
-              <ModelSelector
-                onOpenChange={setModelSelectorOpen}
-                open={modelSelectorOpen}
-              >
-                <ModelSelectorTrigger asChild>
-                  <PromptInputButton>
-                    {selectedModelData?.chefSlug && (
-                      <ModelSelectorLogo
-                        provider={selectedModelData.chefSlug}
-                      />
-                    )}
-                    {selectedModelData?.name && (
-                      <ModelSelectorName>
-                        {selectedModelData.name}
-                      </ModelSelectorName>
-                    )}
-                  </PromptInputButton>
-                </ModelSelectorTrigger>
-                <ModelSelectorContent>
-                  <ModelSelectorInput placeholder="Search models..." />
-                  <ModelSelectorList>
-                    <ModelSelectorEmpty>No models found.</ModelSelectorEmpty>
-                    {["OpenAI", "Anthropic", "Google"].map((chef) => (
-                      <ModelSelectorGroup heading={chef} key={chef}>
-                        {models
-                          .filter((m) => m.chef === chef)
-                          .map((m) => (
-                            <ModelItem
-                              key={m.id}
-                              m={m}
-                              onSelect={handleModelSelect}
-                              selectedModel={model}
-                            />
-                          ))}
-                      </ModelSelectorGroup>
-                    ))}
-                  </ModelSelectorList>
-                </ModelSelectorContent>
-              </ModelSelector>
-            </PromptInputTools>
-            <PromptInputSubmit status={status} />
-          </PromptInputFooter>
-        </PromptInput>
+        <PromptInputSuggestions triggers={suggestionTriggers}>
+          <PromptInput globalDrop multiple onSubmit={handleSubmit}>
+            <PromptInputAttachmentsDisplay />
+            <PromptInputBody>
+              <PromptInputTextarea placeholder="Ask anything, type @ for files or / for commands" />
+            </PromptInputBody>
+            <PromptInputFooter>
+              <PromptInputTools>
+                <PromptInputActionMenu>
+                  <PromptInputActionMenuTrigger />
+                  <PromptInputActionMenuContent>
+                    <PromptInputActionAddAttachments />
+                    <PromptInputActionAddScreenshot />
+                  </PromptInputActionMenuContent>
+                </PromptInputActionMenu>
+                <PromptInputButton>
+                  <GlobeIcon size={16} />
+                  <span>Search</span>
+                </PromptInputButton>
+                <ModelSelector
+                  onOpenChange={setModelSelectorOpen}
+                  open={modelSelectorOpen}
+                >
+                  <ModelSelectorTrigger asChild>
+                    <PromptInputButton>
+                      {selectedModelData?.chefSlug && (
+                        <ModelSelectorLogo
+                          provider={selectedModelData.chefSlug}
+                        />
+                      )}
+                      {selectedModelData?.name && (
+                        <ModelSelectorName>
+                          {selectedModelData.name}
+                        </ModelSelectorName>
+                      )}
+                    </PromptInputButton>
+                  </ModelSelectorTrigger>
+                  <ModelSelectorContent>
+                    <ModelSelectorInput placeholder="Search models..." />
+                    <ModelSelectorList>
+                      <ModelSelectorEmpty>No models found.</ModelSelectorEmpty>
+                      {["OpenAI", "Anthropic", "Google"].map((chef) => (
+                        <ModelSelectorGroup heading={chef} key={chef}>
+                          {models
+                            .filter((m) => m.chef === chef)
+                            .map((m) => (
+                              <ModelItem
+                                key={m.id}
+                                m={m}
+                                onSelect={handleModelSelect}
+                                selectedModel={model}
+                              />
+                            ))}
+                        </ModelSelectorGroup>
+                      ))}
+                    </ModelSelectorList>
+                  </ModelSelectorContent>
+                </ModelSelector>
+              </PromptInputTools>
+              <PromptInputSubmit status={status} />
+            </PromptInputFooter>
+          </PromptInput>
+          <PromptInputSuggestionsDisplay />
+        </PromptInputSuggestions>
       </PromptInputProvider>
     </div>
   );


### PR DESCRIPTION
## Summary

Adds a composable, dependency-free suggestion layer to `PromptInput` for `@` mentions and `/` commands while preserving its textarea and plain-text submission behavior.

## Demo

<table>
  <tr>
    <td width="50%"><img src="https://raw.githubusercontent.com/Rana-Faraz/ai-elements/c406d08ee2bf34ffd525078dca8748b0a9dce890/prompt-input-mention.png" alt="Prompt input showing file mention suggestions after typing @" /></td>
    <td width="50%"><img src="https://raw.githubusercontent.com/Rana-Faraz/ai-elements/c406d08ee2bf34ffd525078dca8748b0a9dce890/prompt-input-command.png" alt="Prompt input showing slash command suggestions after typing /" /></td>
  </tr>
  <tr>
    <td align="center"><strong>@ file mentions</strong></td>
    <td align="center"><strong>/ slash commands</strong></td>
  </tr>
</table>

## What changed

- Adds `PromptInputSuggestions`, `PromptInputSuggestionContent`, `PromptInputSuggestionItem`, and `PromptInputSuggestionEmpty` as opt-in composition primitives.
- Exposes `usePromptInputSuggestions` plus trigger-boundary controls through `allowedPrefixes`, line position, spaces, and query length.
- Supports controlled and uncontrolled inputs, provider-backed forms, IME composition, mid-string replacement, custom insertion, and action-only items.
- Implements combobox/listbox semantics and keyboard navigation with Arrow Up/Down, Enter, Tab, and Escape.
- Documents the API with live mention and command examples, focused tests, and regenerated AI Elements skill artifacts.
- Adds a patch changeset for the new public API.

## Why this approach

This addresses the suggestion discovery and plain-text insertion portion of #179 without adding a rich-editor dependency or changing the existing copy/paste and submission contract. It is complementary to the richer editor direction in #403: consumers can opt into suggestions today while keeping values as plain text.

## Validation

- `pnpm build --filter ai-elements --filter docs` — passed; 194 static pages generated.
- `pnpm test` — passed; 46 files and 966 tests.
- `pnpm generate-skills` — passed; 48 references and 80 examples generated.
- Live docs verified in Chromium for both triggers, keyboard selection, and rendering.
- Changed TSX files pass Oxlint; `git diff origin/main...HEAD --check` passes.

## Notes

- No breaking changes; suggestions are opt-in.
- Related to #179.
- Complements #403.
