### PR TITLE
fix(elements): block Enter submit while streaming in PromptInputTextarea

### DIFF
--- a/packages/elements/__tests__/prompt-input.test.tsx
+++ b/packages/elements/__tests__/prompt-input.test.tsx
@@ -704,6 +704,51 @@ describe("promptInputTextarea", () => {
     expect(onSubmit).not.toHaveBeenCalled();
   });
 
+  it("does not submit on Enter while streaming - #439", async () => {
+    setupPromptInputTests();
+    const onSubmit = vi.fn();
+    const user = userEvent.setup();
+
+    render(
+      <PromptInput onSubmit={onSubmit}>
+        <PromptInputBody>
+          <PromptInputTextarea />
+          <PromptInputSubmit onStop={vi.fn()} status="streaming" />
+        </PromptInputBody>
+      </PromptInput>
+    );
+
+    const textarea = screen.getByPlaceholderText(
+      "What would you like to know?"
+    );
+    await user.type(textarea, "Test");
+    await user.keyboard("{Enter}");
+
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it("does not submit on Enter without a submit button - #439", async () => {
+    setupPromptInputTests();
+    const onSubmit = vi.fn();
+    const user = userEvent.setup();
+
+    render(
+      <PromptInput onSubmit={onSubmit}>
+        <PromptInputBody>
+          <PromptInputTextarea />
+        </PromptInputBody>
+      </PromptInput>
+    );
+
+    const textarea = screen.getByPlaceholderText(
+      "What would you like to know?"
+    );
+    await user.type(textarea, "Test");
+    await user.keyboard("{Enter}");
+
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
   it("does not submit on Enter during IME composition - #21", () => {
     setupPromptInputTests();
     const onSubmit = vi.fn();

--- a/packages/elements/src/prompt-input.tsx
+++ b/packages/elements/src/prompt-input.tsx
@@ -983,12 +983,15 @@ export const PromptInputTextarea = ({
         }
         e.preventDefault();
 
-        // Check if the submit button is disabled before submitting
+        // Check if the submit button is disabled before submitting.
+        // No submit button in the form means the input is not submittable
+        // right now (e.g. PromptInputSubmit renders as a stop button while
+        // streaming), so block Enter in that case too.
         const { form } = e.currentTarget;
         const submitButton = form?.querySelector(
           'button[type="submit"]'
         ) as HTMLButtonElement | null;
-        if (submitButton?.disabled) {
+        if (!submitButton || submitButton.disabled) {
           return;
         }
 


### PR DESCRIPTION
Fixes #439

While streaming with an `onStop` handler, `PromptInputSubmit` renders as `type="button"`, so the Enter guard in `PromptInputTextarea` finds no `button[type="submit"]` and `submitButton?.disabled` evaluates to `undefined`: the form submits mid-stream. This applies the guard proposed in the issue: no submit button in the form blocks Enter, same as a disabled one.

This also answers the behaviour question raised in the issue thread: a composable `PromptInput` without `PromptInputSubmit` no longer submits on Enter. The form has no submit control to consult, and submitting with unknown status is the unsafe default. Both behaviours are pinned in `prompt-input.test.tsx`.

All 952 package tests pass.
